### PR TITLE
Feat/additional user info

### DIFF
--- a/.changeset/orange-donkeys-cough.md
+++ b/.changeset/orange-donkeys-cough.md
@@ -1,0 +1,5 @@
+---
+'web': patch
+---
+
+add new patch endpoint for updating users info

--- a/src/app/admin/api-reference/__tests__/page.test.tsx
+++ b/src/app/admin/api-reference/__tests__/page.test.tsx
@@ -88,9 +88,6 @@ describe('ApiReferencesPage', () => {
 
     // Test User API endpoints
     expect(screen.getByText('/api/user')).toBeInTheDocument();
-    expect(
-      screen.getByText('Get user profile information')
-    ).toBeInTheDocument();
     expect(screen.getByText('/api/user/sync')).toBeInTheDocument();
     expect(screen.getByText('Sync user data')).toBeInTheDocument();
 

--- a/src/app/admin/api-reference/page.tsx
+++ b/src/app/admin/api-reference/page.tsx
@@ -17,8 +17,8 @@ export default function ApiReferencesPage() {
           endpoints={[
             {
               name: '/api/user',
-              description: 'Get user profile information',
-              methods: ['GET', 'DELETE'],
+              description: 'Get or Update user profile information',
+              methods: ['GET', 'DELETE', 'PATCH'],
             },
             {
               name: '/api/user/sync',

--- a/src/app/admin/api-reference/user/page.tsx
+++ b/src/app/admin/api-reference/user/page.tsx
@@ -450,10 +450,11 @@ function RatingsCard({ ratings }: RatingsCardProps) {
                         {[1, 2, 3, 4, 5].map((star) => (
                           <span
                             key={`rating-star-${rating.id}-${star}`}
-                            className={`text-sm ${rating.rating >= star
-                              ? 'text-yellow-400'
-                              : 'text-gray-300'
-                              }`}
+                            className={`text-sm ${
+                              rating.rating >= star
+                                ? 'text-yellow-400'
+                                : 'text-gray-300'
+                            }`}
                           >
                             ★
                           </span>

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -144,3 +144,43 @@ export async function DELETE(
     );
   }
 }
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const userId = await getUserId(request);
+
+    const { email, firstName, lastName } = await request.json();
+
+    const client = await clerkClient();
+    // update email first
+    await client.emailAddresses.createEmailAddress({
+      userId,
+      emailAddress: email,
+      primary: true,
+      verified: true,
+    });
+
+    // update name if provided
+    if (firstName || lastName) {
+      await client.users.updateUser(userId, {
+        firstName,
+        lastName,
+      });
+    }
+
+    return NextResponse.json({
+      message: 'User updated successfully',
+      userId: userId,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    log.error('Unexpected error in /api/user/patch:', error);
+    return NextResponse.json(
+      {
+        error: 'Unexpected error',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
#### Description:
- add `PATCH` support to `/api/user`
- will be called by `AdditionalUserInfoSheet` in iOS app, when a user registers with apple and chooses not to share their email with us
- only requires email, but accepts first and last name as well
- updates admin docs / `/admin/api-reference/user` page to allow us to test from there
- show users favorites / ratings on user admin page
- link to details page for each

#### Attachment(s):

##### iOS flow:
<img width="1317" alt="Screenshot 2025-03-28 at 1 28 43 PM" src="https://github.com/user-attachments/assets/cfcf202f-5e18-4677-8aea-914932bc54f0" />

##### Admin app form:
<img width="1340" alt="Screenshot 2025-03-28 at 4 07 41 PM" src="https://github.com/user-attachments/assets/3528d427-5fdc-4804-adee-4d1cf5402a60" />

##### Postman Collection Update:
<img width="860" alt="Screenshot 2025-03-28 at 4 08 50 PM" src="https://github.com/user-attachments/assets/d420084b-3c81-4c6c-aea8-d89a623c490b" />

##### Other small updates to user admin page:
https://github.com/user-attachments/assets/485b99ce-f0cf-4874-b5c0-1f6d9582a49e

#### Note(s):