### PR TITLE
feat: make details endpoint return prisma type

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,13 +393,7 @@ The application defines several Inngest functions for background processing
 
 ### Event Flow
 
-1. **Event Triggering**: Events are sent to Inngest from various parts of the application:
-   ```typescript
-   await inngest.send({
-     name: 'places/upsert',
-     data: { id, details },
-   });
-   ```
+1. **Event Triggering**: Events are sent to Inngest from various parts of the application
 
 2. **Event Processing**: Inngest functions process these events asynchronously:
    - Events are queued and processed in the background

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,14 +10,16 @@ datasource db {
 }
 
 model User {
-  id        String     @id @unique
-  email     String     @unique
+  id        String  @id @unique
+  email     String  @unique
   username  String?
   firstName String?
   lastName  String?
   imageUrl  String?
-  createdAt DateTime   @default(now())
-  updatedAt DateTime   @default(now()) @updatedAt
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
   favorites Favorite[]
   ratings   Rating[]
   merchant  Merchant?
@@ -26,33 +28,59 @@ model User {
 }
 
 model Place {
-  id          String     @id @default(cuid())
-  name        String?
-  description String?
-  latitude    Float?
-  longitude   Float?
-  address     String?
-  merchantId  String?
-  createdAt   DateTime   @default(now())
-  updatedAt   DateTime   @default(now()) @updatedAt
-  favorites   Favorite[]
-  photos      Photo[]
-  ratings     Rating[]
-  reviews     Review[]
-  merchant    Merchant?  @relation(fields: [merchantId], references: [id])
+  id                     String   @id @default(cuid())
+  name                   String
+  latitude               Float
+  longitude              Float
+  address                String
+  merchantId             String?
+  allowsDogs             Boolean
+  delivery               Boolean
+  editorialSummary       String?
+  generativeSummary      String?
+  goodForChildren        Boolean
+  dineIn                 Boolean
+  goodForGroups          Boolean
+  isFree                 Boolean
+  liveMusic              Boolean
+  menuForChildren        Boolean
+  outdoorSeating         Boolean
+  acceptsCashOnly        Boolean?
+  acceptsCreditCards     Boolean?
+  acceptsDebitCards      Boolean?
+  priceLevel             Int? // 1-4 inclusive
+  primaryTypeDisplayName String?
+  googleRating           Float
+  servesCoffee           Boolean
+  servesDessert          Boolean
+  takeout                Boolean
+  restroom               Boolean
+  openNow                Boolean?
+  userRatingCount        Int
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  favorites Favorite[]
+  photos    Photo[]
+  ratings   Rating[]
+  reviews   Review[]
+  merchant  Merchant?  @relation(fields: [merchantId], references: [id])
 
   @@index([name])
   @@index([merchantId])
 }
 
 model Favorite {
-  id        String   @id @default(cuid())
-  userId    String
-  placeId   String
+  id      String @id @default(cuid())
+  userId  String
+  placeId String
+
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
-  place     Place    @relation(fields: [placeId], references: [id], onDelete: Cascade)
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  place Place @relation(fields: [placeId], references: [id], onDelete: Cascade)
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, placeId])
   @@index([userId])
@@ -60,14 +88,16 @@ model Favorite {
 }
 
 model Rating {
-  id        String   @id @default(cuid())
-  userId    String
-  placeId   String
-  rating    Int
+  id      String @id @default(cuid())
+  userId  String
+  placeId String
+  rating  Int
+
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
-  place     Place    @relation(fields: [placeId], references: [id], onDelete: Cascade)
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  place Place @relation(fields: [placeId], references: [id], onDelete: Cascade)
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, placeId])
   @@index([userId])
@@ -81,32 +111,44 @@ model Category {
   keywords String[]
 }
 
+enum ReviewStatus {
+  DEFAULT
+  HIDDEN
+  FEATURED
+}
+
 model Review {
-  id                             String   @id @default(cuid())
+  id                             String       @id @default(cuid())
   placeId                        String
-  name                           String
   relativePublishTimeDescription String
   rating                         Int
   text                           String
-  createdAt                      DateTime @default(now())
-  updatedAt                      DateTime @default(now()) @updatedAt
-  place                          Place    @relation(fields: [placeId], references: [id], onDelete: Cascade)
+  status                         ReviewStatus @default(DEFAULT)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  place Place @relation(fields: [placeId], references: [id], onDelete: Cascade)
 }
 
 model Photo {
-  id        String   @id @default(cuid())
-  placeId   String
-  url       String
+  id      String @id @default(cuid())
+  placeId String
+  url     String
+
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
-  place     Place    @relation(fields: [placeId], references: [id], onDelete: Cascade)
+
+  place Place @relation(fields: [placeId], references: [id], onDelete: Cascade)
 }
 
 model Merchant {
-  id        String   @id @default(cuid())
-  userId    String   @unique
+  id     String @id @default(cuid())
+  userId String @unique
+
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
-  places    Place[]
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  places Place[]
+  user   User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 }

--- a/src/__fixtures__/api/places/details/google-response.json
+++ b/src/__fixtures__/api/places/details/google-response.json
@@ -1,38 +1,112 @@
 {
-  "name": "places/ChIJV_U7LED_wokRul5d4R2YP_g",
-  "rating": 4,
-  "priceLevel": "PRICE_LEVEL_MODERATE",
-  "userRatingCount": 4508,
-  "primaryTypeDisplayName": {
-    "text": "Diner"
+  "id": "ChIJifIePKtZwokRVZ-UdRGkZzs",
+  "name": "places/ChIJifIePKtZwokRVZ-UdRGkZzs",
+  "displayName": {
+    "text": "Joe's Pizza Broadway"
   },
-  "takeout": true,
+  "primaryTypeDisplayName": {
+    "text": "Pizza Restaurant"
+  },
   "delivery": true,
   "dineIn": true,
-  "currentOpeningHours": {
-    "openNow": false
-  },
-  "editorialSummary": {
-    "text": "Old-school 1940s art deco diner serving breakfast & American comfort food 24/7."
-  },
-  "outdoorSeating": true,
-  "liveMusic": false,
-  "menuForChildren": true,
-  "servesDessert": true,
-  "servesCoffee": true,
   "goodForChildren": true,
-  "allowsDogs": false,
-  "restroom": true,
+  "restroom": false,
   "goodForGroups": true,
   "paymentOptions": {
     "acceptsCreditCards": true,
     "acceptsDebitCards": true,
-    "acceptsCashOnly": false,
-    "acceptsNfc": true
+    "acceptsCashOnly": false
   },
+  "reviews": [
+    {
+      "name": "places/ChIJifIePKtZwokRVZ-UdRGkZzs/reviews/ChdDSUhNMG9nS0VJQ0FnTUR3eGREQzV3RRAB",
+      "relativePublishTimeDescription": "in the last week",
+      "rating": 5,
+      "text": {
+        "text": "Came to Joe's Pizza in Times Square after hearing all the hype—and it absolutely lived up to it. The place was packed (as expected), but the line moved fast and the staff kept things flowing smoothly.\n\nI got a pepperoni slice with sausage, mushrooms, and red onions—super flavorful, thin crust, crispy on the edges, and not overly greasy. It had that perfect NYC street slice taste you hope for. Just classic and satisfying.\n\nThe vibe inside is pure New York: walls covered in celebrity photos, press clippings, and Spider-Man references. It feels like a piece of pizza history. Despite being in such a tourist-heavy area, Joe's still feels authentic and delivers the real deal.\n\nIf you're in NYC and want a proper slice, this is the spot. I'd definitely come back.",
+        "languageCode": "en"
+      },
+      "originalText": {
+        "text": "Came to Joe's Pizza in Times Square after hearing all the hype—and it absolutely lived up to it. The place was packed (as expected), but the line moved fast and the staff kept things flowing smoothly.\n\nI got a pepperoni slice with sausage, mushrooms, and red onions—super flavorful, thin crust, crispy on the edges, and not overly greasy. It had that perfect NYC street slice taste you hope for. Just classic and satisfying.\n\nThe vibe inside is pure New York: walls covered in celebrity photos, press clippings, and Spider-Man references. It feels like a piece of pizza history. Despite being in such a tourist-heavy area, Joe's still feels authentic and delivers the real deal.\n\nIf you're in NYC and want a proper slice, this is the spot. I'd definitely come back.",
+        "languageCode": "en"
+      }
+    },
+    {
+      "name": "places/ChIJifIePKtZwokRVZ-UdRGkZzs/reviews/ChZDSUhNMG9nS0VJQ0FnTUN3LWFqUUpREAE",
+      "relativePublishTimeDescription": "a week ago",
+      "rating": 4,
+      "text": {
+        "text": "Joe's Pizza is a very popular and well-known restaurant in New York City. Although the place is really not bad, it cannot be called unsurpassed. However, if you are in New York, you should visit this place at least once to try the insanely famous pizza slices.\n\nThe pizzeria is very popular, especially because of its location on Broadway. Given this, in the evening, you need to be prepared for a long line - during our visit, it stretched for an entire street to the next intersection, moving at an average speed.\n\nIt was very cozy inside, with a really cool atmosphere. Despite the large number of visitors, we even managed to find a seat and enjoy the pizza inside. We ordered three different slices of pizza (pepperoni, regular cheese, and cheese with extra mozzarella), all of which were large and fresh. As for the taste, I can say that the pizza was standard tasty without any special features, but not the best you can find in New York. There are many lesser-known pizzerias on the streets where you can buy a similar pizza at a lower price, and it tastes and is identical in size.\nA nice bonus was the opportunity to add extra Parmesan or other spices for free.\n\nTo summarize, it is worth visiting Joe's Pizza at least once while in New York, if only because of the incredible atmosphere of the place. However, I would not recommend wasting time waiting in line for a piece of pizza again, as the city offers many other places with a variety of delicious food.",
+        "languageCode": "en"
+      },
+      "originalText": {
+        "text": "Joe's Pizza is a very popular and well-known restaurant in New York City. Although the place is really not bad, it cannot be called unsurpassed. However, if you are in New York, you should visit this place at least once to try the insanely famous pizza slices.\n\nThe pizzeria is very popular, especially because of its location on Broadway. Given this, in the evening, you need to be prepared for a long line - during our visit, it stretched for an entire street to the next intersection, moving at an average speed.\n\nIt was very cozy inside, with a really cool atmosphere. Despite the large number of visitors, we even managed to find a seat and enjoy the pizza inside. We ordered three different slices of pizza (pepperoni, regular cheese, and cheese with extra mozzarella), all of which were large and fresh. As for the taste, I can say that the pizza was standard tasty without any special features, but not the best you can find in New York. There are many lesser-known pizzerias on the streets where you can buy a similar pizza at a lower price, and it tastes and is identical in size.\nA nice bonus was the opportunity to add extra Parmesan or other spices for free.\n\nTo summarize, it is worth visiting Joe's Pizza at least once while in New York, if only because of the incredible atmosphere of the place. However, I would not recommend wasting time waiting in line for a piece of pizza again, as the city offers many other places with a variety of delicious food.",
+        "languageCode": "en"
+      }
+    },
+    {
+      "name": "places/ChIJifIePKtZwokRVZ-UdRGkZzs/reviews/ChdDSUhNMG9nS0VJQ0FnTUN3ck02QjBBRRAB",
+      "relativePublishTimeDescription": "2 weeks ago",
+      "rating": 5,
+      "text": {
+        "text": "Had to try the famous Joe's Pizza and it did not disappoint! There was about a 15-20 minute line to get in. It was super busy on a Sunday night at 10pm. But it was worth the wait, they churn out fresh Pizzas constantly and only takes a couple of minutes for a slice to be ready after you order.",
+        "languageCode": "en"
+      },
+      "originalText": {
+        "text": "Had to try the famous Joe's Pizza and it did not disappoint! There was about a 15-20 minute line to get in. It was super busy on a Sunday night at 10pm. But it was worth the wait, they churn out fresh Pizzas constantly and only takes a couple of minutes for a slice to be ready after you order.",
+        "languageCode": "en"
+      }
+    },
+    {
+      "name": "places/ChIJifIePKtZwokRVZ-UdRGkZzs/reviews/ChZDSUhNMG9nS0VJQ0FnTUN3amZYRUZBEAE",
+      "relativePublishTimeDescription": "a week ago",
+      "rating": 5,
+      "text": {
+        "text": "We waited in line for about twenty minutes. It was worth it. The slices were big and the crust ultra thin. The toppings were classic. we tried three different ones and they were equally delicious. Our hotel is next door so we'll definitely have another slice or two before going home. Thank you Joe's!",
+        "languageCode": "en"
+      },
+      "originalText": {
+        "text": "We waited in line for about twenty minutes. It was worth it. The slices were big and the crust ultra thin. The toppings were classic. we tried three different ones and they were equally delicious. Our hotel is next door so we'll definitely have another slice or two before going home. Thank you Joe's!",
+        "languageCode": "en"
+      }
+    },
+    {
+      "name": "places/ChIJifIePKtZwokRVZ-UdRGkZzs/reviews/ChdDSUhNMG9nS0VJQ0FnTURRMGFQdXdRRRAB",
+      "relativePublishTimeDescription": "3 weeks ago",
+      "rating": 5,
+      "text": {
+        "text": "There was a pretty long line when I walked past and decided to join. It moved quickly, with no more than a 15 minute wait. I got the pepperoni and it was everything you need in a slice of pizza: hot, cheesy with just the right amount of sauce. Whether you're a Spiderman fan or just hungry, I'd recommend.",
+        "languageCode": "en"
+      },
+      "originalText": {
+        "text": "There was a pretty long line when I walked past and decided to join. It moved quickly, with no more than a 15 minute wait. I got the pepperoni and it was everything you need in a slice of pizza: hot, cheesy with just the right amount of sauce. Whether you're a Spiderman fan or just hungry, I'd recommend.",
+        "languageCode": "en"
+      }
+    }
+  ],
+  "rating": 4.5,
+  "priceLevel": "PRICE_LEVEL_INEXPENSIVE",
+  "userRatingCount": 21260,
+  "currentOpeningHours": {
+    "openNow": true
+  },
+  "takeout": true,
+  "editorialSummary": {
+    "text": "Modern outpost of a longtime counter-serve pizza joint prepping New York-style slices and pies."
+  },
+  "outdoorSeating": true,
+  "liveMusic": false,
+  "menuForChildren": false,
+  "servesDessert": false,
+  "servesCoffee": false,
   "generativeSummary": {
     "overview": {
-      "text": "Long-standing diner with an Art Deco vibe serving breakfast-to-dinner American eats and cocktails."
+      "text": "Casual spot offering many types of New York-style pizza, including by the slice, until late at night."
     }
-  }
+  },
+  "location": {
+    "latitude": 40.754679499999995,
+    "longitude": -73.9870291
+  },
+  "formattedAddress": "1435 Broadway, New York, NY 10018, USA"
 }

--- a/src/__tests__/api/merchant/associate/route.test.ts
+++ b/src/__tests__/api/merchant/associate/route.test.ts
@@ -2,6 +2,8 @@ import { NextRequest } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from '@/app/api/merchant/associate/route';
+import type { PlaceWithReviews } from '@/types/details';
+import type { Place, Review } from '@prisma/client';
 
 // Mock dependencies
 vi.mock('@clerk/nextjs/server', () => ({
@@ -40,6 +42,9 @@ const mockTx = {
   },
 };
 
+// Fixed mock date for consistent testing
+const mockDate = new Date('2023-01-01T12:00:00Z');
+
 // Mock data
 const mockUser = {
   id: 'user-1',
@@ -47,35 +52,120 @@ const mockUser = {
   username: 'testuser',
 };
 
-const mockPlaceDetails = {
-  displayName: 'Test Place Display Name',
-  editorialSummary: 'A great test place',
+const mockGoogleDetails: PlaceWithReviews = {
+  id: 'place-1',
+  name: 'Test Place',
+  displayName: 'Test Place',
+  googleRating: 4.5,
+  rating: 4.5,
+  latitude: 37.7749,
+  longitude: -122.4194,
   location: {
     latitude: 37.7749,
     longitude: -122.4194,
   },
+  paymentOptions: {
+    acceptsCreditCards: true,
+    acceptsDebitCards: true,
+    acceptsCashOnly: false,
+  },
   reviews: [
     {
-      name: 'Reviewer 1',
+      id: 'review_1',
+      placeId: 'place-1',
       relativePublishTimeDescription: '2 days ago',
       rating: 5,
-      text: { text: 'Great place!' },
+      text: 'Great place!',
+      status: 'DEFAULT',
+    },
+    {
+      id: 'review_2',
+      placeId: 'place-1',
+      relativePublishTimeDescription: '1 week ago',
+      rating: 4,
+      text: 'Good experience',
+      status: 'DEFAULT',
     },
   ],
+  priceLevel: 2,
+  userRatingCount: 100,
+  primaryTypeDisplayName: 'Restaurant',
+  takeout: true,
+  delivery: false,
+  dineIn: true,
+  editorialSummary: 'A great restaurant with amazing food',
+  outdoorSeating: true,
+  liveMusic: false,
+  menuForChildren: true,
+  servesDessert: true,
+  servesCoffee: true,
+  goodForChildren: true,
+  goodForGroups: true,
+  allowsDogs: false,
+  restroom: true,
+  acceptsCashOnly: false,
+  acceptsCreditCards: true,
+  acceptsDebitCards: true,
+  generativeSummary: 'This is a generative summary of the restaurant',
+  isFree: false,
+  address: '123 Test St',
+  openNow: true,
+  merchantId: null,
 };
 
-const mockPlace = {
+const mockPlace: Place = {
   id: 'place-1',
   name: 'Test Place',
-  description: 'A great test place',
   latitude: 37.7749,
   longitude: -122.4194,
+  createdAt: mockDate,
+  updatedAt: mockDate,
+  address: '123 Test St',
   merchantId: null,
-  photos: [],
-  ratings: [],
-  reviews: [],
-  favorites: [],
+  allowsDogs: false,
+  delivery: false,
+  editorialSummary: 'A great restaurant with amazing food',
+  generativeSummary: 'This is a generative summary of the restaurant',
+  goodForChildren: true,
+  dineIn: true,
+  goodForGroups: true,
+  isFree: false,
+  liveMusic: false,
+  menuForChildren: true,
+  outdoorSeating: true,
+  acceptsCashOnly: false,
+  acceptsCreditCards: true,
+  acceptsDebitCards: true,
+  priceLevel: 2,
+  primaryTypeDisplayName: 'Restaurant',
+  googleRating: 4.5,
+  servesCoffee: true,
+  servesDessert: true,
+  takeout: true,
+  restroom: true,
+  openNow: true,
+  userRatingCount: 100,
 };
+
+const mockTransformedReviews: Omit<
+  Review,
+  'placeId' | 'createdAt' | 'updatedAt'
+>[] = [
+  {
+    id: 'review_1',
+    relativePublishTimeDescription: '2 days ago',
+    rating: 5,
+    text: 'Great place!',
+    status: 'DEFAULT',
+  },
+  {
+    id: 'review_2',
+    relativePublishTimeDescription: '1 week ago',
+    rating: 4,
+    text: 'Good experience',
+    status: 'DEFAULT',
+  },
+];
 
 const mockMerchant = {
   id: 'merchant-1',
@@ -95,6 +185,9 @@ function createNextRequest(body: RequestBody): NextRequest {
 describe('Merchant Associate Route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Set up fake timers
+    vi.useFakeTimers();
+    vi.setSystemTime(mockDate);
     // Default auth mock to return a userId
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(auth).mockResolvedValue({ userId: 'user-1' } as any);
@@ -132,12 +225,18 @@ describe('Merchant Associate Route', () => {
     vi.mocked(mockTx.place.findUnique).mockResolvedValue(null);
     vi.mocked(mockTx.merchant.findUnique).mockResolvedValue(null);
     vi.mocked(mockTx.merchant.create).mockResolvedValue(mockMerchant);
-    vi.mocked(mockTx.place.upsert).mockResolvedValue(mockPlace);
+    vi.mocked(mockTx.place.upsert).mockResolvedValue({
+      ...mockPlace,
+      photos: [],
+      ratings: [],
+      reviews: mockTransformedReviews,
+      favorites: [],
+    });
 
     // Mock the place details API response
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ data: mockPlaceDetails }),
+      json: () => Promise.resolve({ data: mockGoogleDetails }),
     });
 
     const request = createNextRequest({ placeId: 'place-1' });
@@ -149,22 +248,41 @@ describe('Merchant Associate Route', () => {
     expect(mockTx.place.upsert).toHaveBeenCalledWith({
       where: { id: 'place-1' },
       create: {
-        id: 'place-1',
-        name: mockPlaceDetails.displayName,
-        description: mockPlaceDetails.editorialSummary,
-        latitude: mockPlaceDetails.location.latitude,
-        longitude: mockPlaceDetails.location.longitude,
+        id: mockGoogleDetails.id,
+        name: mockGoogleDetails.name,
+        latitude: mockGoogleDetails.latitude,
+        longitude: mockGoogleDetails.longitude,
+        address: mockGoogleDetails.address,
+        merchantId: null,
+        allowsDogs: mockGoogleDetails.allowsDogs,
+        delivery: mockGoogleDetails.delivery,
+        editorialSummary: mockGoogleDetails.editorialSummary,
+        generativeSummary: mockGoogleDetails.generativeSummary,
+        goodForChildren: mockGoogleDetails.goodForChildren,
+        dineIn: mockGoogleDetails.dineIn,
+        goodForGroups: mockGoogleDetails.goodForGroups,
+        isFree: mockGoogleDetails.isFree,
+        liveMusic: mockGoogleDetails.liveMusic,
+        menuForChildren: mockGoogleDetails.menuForChildren,
+        outdoorSeating: mockGoogleDetails.outdoorSeating,
+        acceptsCashOnly: mockGoogleDetails.acceptsCashOnly,
+        acceptsCreditCards: mockGoogleDetails.acceptsCreditCards,
+        acceptsDebitCards: mockGoogleDetails.acceptsDebitCards,
+        priceLevel: mockGoogleDetails.priceLevel,
+        primaryTypeDisplayName: mockGoogleDetails.primaryTypeDisplayName,
+        googleRating: mockGoogleDetails.googleRating,
+        servesCoffee: mockGoogleDetails.servesCoffee,
+        servesDessert: mockGoogleDetails.servesDessert,
+        takeout: mockGoogleDetails.takeout,
+        restroom: mockGoogleDetails.restroom,
+        openNow: mockGoogleDetails.openNow,
+        userRatingCount: mockGoogleDetails.userRatingCount,
         reviews: {
           createMany: {
-            data: [
-              {
-                name: mockPlaceDetails.reviews[0].name,
-                relativePublishTimeDescription:
-                  mockPlaceDetails.reviews[0].relativePublishTimeDescription,
-                rating: mockPlaceDetails.reviews[0].rating,
-                text: mockPlaceDetails.reviews[0].text.text,
-              },
-            ],
+            data: mockGoogleDetails.reviews.map((review) => ({
+              ...review,
+              placeId: mockGoogleDetails.id,
+            })),
           },
         },
       },
@@ -178,6 +296,7 @@ describe('Merchant Associate Route', () => {
     });
     expect(response.status).toBe(200);
     expect(data.success).toBe(true);
+    expect(data.data.merchant).toEqual(mockMerchant);
   });
 
   it('should not make request to create place if it already exists', async () => {

--- a/src/__tests__/api/places/details/route.test.ts
+++ b/src/__tests__/api/places/details/route.test.ts
@@ -33,39 +33,47 @@ describe('Places Details API', () => {
 
   const mockDetailsResponse: DetailResponse = {
     data: {
+      id: mockPlaceId,
       name: 'Test Place',
-      reviews: [],
-      rating: 4.5,
-      priceLevel: 2,
-      userRatingCount: 100,
-      openNow: true,
-      displayName: 'Test Place Display Name',
-      primaryTypeDisplayName: 'Restaurant',
-      takeout: true,
+      latitude: 37.7749,
+      longitude: -122.4194,
+      address: '123 Test St, Test City, TC 12345',
+      merchantId: null,
+      allowsDogs: false,
       delivery: true,
-      dineIn: true,
       editorialSummary: 'A great place to eat',
-      outdoorSeating: true,
+      generativeSummary: 'This is a generated summary of the place',
+      goodForChildren: true,
+      dineIn: true,
+      goodForGroups: true,
+      isFree: false,
       liveMusic: false,
       menuForChildren: true,
-      servesDessert: true,
+      outdoorSeating: true,
+      acceptsCashOnly: false,
+      acceptsCreditCards: true,
+      acceptsDebitCards: true,
+      priceLevel: 2,
+      primaryTypeDisplayName: 'Restaurant',
+      googleRating: 4.5,
       servesCoffee: true,
-      goodForChildren: true,
-      goodForGroups: true,
-      allowsDogs: false,
+      servesDessert: true,
+      takeout: true,
       restroom: true,
+      openNow: true,
+      userRatingCount: 100,
+      reviews: [],
+      displayName: 'Test Place Display Name',
+      location: {
+        latitude: 37.7749,
+        longitude: -122.4194,
+      },
       paymentOptions: {
         acceptsCreditCards: true,
         acceptsDebitCards: true,
         acceptsCashOnly: false,
       },
-      generativeSummary: 'This is a generated summary of the place',
-      isFree: false,
-      location: {
-        latitude: 37.7749,
-        longitude: -122.4194,
-      },
-      formattedAddress: '123 Test St, Test City, TC 12345',
+      rating: 4.5,
     },
     count: 1,
     cacheHit: false,
@@ -113,7 +121,7 @@ describe('Places Details API', () => {
 
     // Verify Inngest event was sent
     expect(inngest.send).toHaveBeenCalledWith({
-      name: 'places/upsert',
+      name: 'places/create',
       data: {
         id: mockPlaceId,
         details: mockDetailsResponse,
@@ -152,7 +160,7 @@ describe('Places Details API', () => {
 
     // Verify Inngest event was still sent even with cached data
     expect(inngest.send).toHaveBeenCalledWith({
-      name: 'places/upsert',
+      name: 'places/create',
       data: {
         id: mockPlaceId,
         details: cachedResponse,
@@ -180,7 +188,7 @@ describe('Places Details API', () => {
 
     // Verify Inngest event was sent
     expect(inngest.send).toHaveBeenCalledWith({
-      name: 'places/upsert',
+      name: 'places/create',
       data: {
         id: mockPlaceId,
         details: mockDetailsResponse,
@@ -256,7 +264,7 @@ describe('Places Details API', () => {
 
     // Verify Inngest event was sent
     expect(inngest.send).toHaveBeenCalledWith({
-      name: 'places/upsert',
+      name: 'places/create',
       data: {
         id: mockPlaceId,
         details: mockDetailsResponse,

--- a/src/__tests__/api/places/rating/route.test.ts
+++ b/src/__tests__/api/places/rating/route.test.ts
@@ -1,11 +1,21 @@
-import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
+import { NextRequest } from 'next/server';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { POST } from '@/app/api/places/rating/route';
+import { POST, GET } from '@/app/api/places/rating/route';
 import { inngest } from '@/inngest/client';
 import { prisma } from '@/lib/db';
 import { getUserId } from '@/services/user/get-user-id';
 import type { User, Place, Rating } from '@prisma/client';
+
+// Helper function to extract JSON from response
+async function getResponseBody(response: Response) {
+  const text = await response.text();
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    console.error('Error parsing response JSON:', error);
+    return text;
+  }
+}
 
 // Mock dependencies
 vi.mock('@/lib/db', () => ({
@@ -38,36 +48,6 @@ vi.mock('@/inngest/client', () => ({
   },
 }));
 
-// Mock NextRequest
-class MockNextRequest {
-  private body: Record<string, unknown>;
-  headers: Headers;
-
-  constructor(
-    body: Record<string, unknown>,
-    headers: Record<string, string> = {}
-  ) {
-    this.body = body;
-    this.headers = new Headers(headers);
-  }
-
-  async json() {
-    return this.body;
-  }
-
-  clone() {
-    return this;
-  }
-}
-
-vi.mock('next/server', () => {
-  return {
-    NextResponse: {
-      json: vi.fn((data, options) => ({ data, options })),
-    },
-  };
-});
-
 // Mock logger
 vi.mock('@/utils/log', () => ({
   log: {
@@ -81,8 +61,12 @@ describe('Rating API Routes', () => {
   const FIXED_DATE = new Date('2023-01-01T12:00:00Z');
 
   // Mock data
+  const mockUserId = 'user123';
+  const mockPlaceId = 'place123';
+  const mockRatingId = 'rating123';
+
   const mockPlace: Place = {
-    id: 'place_123',
+    id: mockPlaceId,
     name: 'Test Place',
     latitude: 37.7749,
     longitude: -122.4194,
@@ -116,7 +100,7 @@ describe('Rating API Routes', () => {
   };
 
   const mockUser: User = {
-    id: 'user_123',
+    id: mockUserId,
     email: 'test@example.com',
     firstName: 'Test',
     lastName: 'User',
@@ -127,77 +111,103 @@ describe('Rating API Routes', () => {
   };
 
   const createMockRating = (rating: number): Rating => ({
-    id: 'rating_123',
-    userId: 'user_123',
-    placeId: 'place_123',
+    id: mockRatingId,
+    userId: mockUserId,
+    placeId: mockPlaceId,
     rating,
-    createdAt: FIXED_DATE,
-    updatedAt: FIXED_DATE,
+    // @ts-expect-error - This is a mock
+    createdAt: FIXED_DATE.toISOString(),
+    // @ts-expect-error - This is a mock
+    updatedAt: FIXED_DATE.toISOString(),
   });
 
   beforeEach(() => {
-    vi.clearAllMocks();
-    // Use fake timers and set a fixed system time
+    // Set up fake timers
     vi.useFakeTimers();
     vi.setSystemTime(FIXED_DATE);
-    // Default mock for getUserId to return a valid user ID
-    vi.mocked(getUserId).mockResolvedValue('user_123');
+
+    // Reset mocks before each test
+    vi.resetAllMocks();
+
+    // Default getUserId mock to return a userId
+    vi.mocked(getUserId).mockResolvedValue(mockUserId);
   });
 
   afterEach(() => {
-    // Restore real timers after each test
+    vi.resetAllMocks();
+    // Restore real timers
     vi.useRealTimers();
   });
 
   describe('POST /api/places/rating', () => {
     it('should return 500 if getUserId throws an Unauthorized error', async () => {
-      const mockRequest = new MockNextRequest(
-        {},
-        {
-          authorization: 'Bearer invalid-token',
-        }
-      ) as unknown as NextRequest;
-
       // Mock getUserId to throw Unauthorized error
       vi.mocked(getUserId).mockRejectedValue(new Error('Unauthorized'));
 
-      await POST(mockRequest);
+      const mockRequest = new NextRequest(
+        'http://localhost/api/places/rating',
+        {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer invalid-token',
+          },
+        }
+      );
+
+      const response = await POST(mockRequest);
+      const body = await getResponseBody(response);
 
       expect(getUserId).toHaveBeenCalledWith(mockRequest);
-      expect(NextResponse.json).toHaveBeenCalledWith(
-        { error: 'Failed to process rating' },
-        { status: 500 }
-      );
+      expect(response.status).toBe(500);
+      expect(body).toEqual({ error: 'Failed to process rating' });
     });
 
     it('should return 400 if placeId is not provided', async () => {
-      const mockRequest = new MockNextRequest(
-        {},
-        {
-          authorization: 'Bearer valid-token',
-        }
-      ) as unknown as NextRequest;
-
       // Mock user found
       vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser);
 
-      await POST(mockRequest);
-
-      expect(NextResponse.json).toHaveBeenCalledWith(
-        { error: 'Place ID is required' },
-        { status: 400 }
+      const mockRequest = new NextRequest(
+        'http://localhost/api/places/rating',
+        {
+          method: 'POST',
+          body: JSON.stringify({}),
+        }
       );
+
+      const response = await POST(mockRequest);
+      const body = await getResponseBody(response);
+
+      expect(response.status).toBe(400);
+      expect(body).toEqual({ error: 'Place ID is required' });
     });
 
-    it('should return 400 if rating is not provided for a new rating', async () => {
-      const mockRequest = new MockNextRequest(
+    it('should return 404 if user is not found', async () => {
+      // Mock user not found
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+
+      const mockRequest = new NextRequest(
+        'http://localhost/api/places/rating',
         {
-          placeId: 'place_123',
-        },
-        {
-          authorization: 'Bearer valid-token',
+          method: 'POST',
+          body: JSON.stringify({ placeId: mockPlaceId }),
         }
-      ) as unknown as NextRequest;
+      );
+
+      const response = await POST(mockRequest);
+      const body = await getResponseBody(response);
+
+      expect(response.status).toBe(404);
+      expect(body).toEqual({ error: 'User not found' });
+    });
+
+    it('should return 400 if rating is not provided', async () => {
+      const mockRequest = new NextRequest(
+        'http://localhost/api/places/rating',
+        {
+          method: 'POST',
+          body: JSON.stringify({ placeId: mockPlaceId }),
+        }
+      );
 
       // Mock user found
       vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser);
@@ -208,23 +218,24 @@ describe('Rating API Routes', () => {
       // Mock no existing rating found
       vi.mocked(prisma.rating.findUnique).mockResolvedValue(null);
 
-      await POST(mockRequest);
+      const response = await POST(mockRequest);
+      const body = await getResponseBody(response);
 
-      expect(NextResponse.json).toHaveBeenCalledWith(
-        { error: 'Rating is required' },
-        { status: 400 }
-      );
+      expect(response.status).toBe(400);
+      expect(body).toEqual({ error: 'Rating is required' });
     });
 
-    it('should remove an existing rating if no new rating is provided', async () => {
-      const mockRequest = new MockNextRequest(
+    it('should remove an existing rating if provided rating is the same as the existing rating', async () => {
+      const mockRequest = new NextRequest(
+        'http://localhost/api/places/rating',
         {
-          placeId: 'place_123',
-        },
-        {
-          authorization: 'Bearer valid-token',
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer valid-token',
+          },
+          body: JSON.stringify({ placeId: mockPlaceId, rating: 4 }),
         }
-      ) as unknown as NextRequest;
+      );
 
       // Mock user found
       vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser);
@@ -236,60 +247,36 @@ describe('Rating API Routes', () => {
       const existingRating = createMockRating(4);
       vi.mocked(prisma.rating.findUnique).mockResolvedValue(existingRating);
 
-      // Mock rating deletion (since no rating is provided, it should delete existing)
+      // Mock rating deletion (since no new rating is provided, it should delete existing)
       vi.mocked(prisma.rating.delete).mockResolvedValue(existingRating);
 
-      await POST(mockRequest);
+      const response = await POST(mockRequest);
+      const body = await getResponseBody(response);
 
       // The implementation should delete the rating if no new rating is provided
       expect(prisma.rating.delete).toHaveBeenCalledWith({
-        where: { id: 'rating_123' },
+        where: { id: mockRatingId },
       });
-      expect(NextResponse.json).toHaveBeenCalledWith(
-        {
+      expect(body).toEqual(
+        expect.objectContaining({
           message: 'Rating removed',
           rating: existingRating,
           action: 'removed',
-        },
-        { status: 200 }
-      );
-    });
-
-    it('should return 404 if user is not found', async () => {
-      const mockRequest = new MockNextRequest(
-        {
-          placeId: 'place_123',
-          rating: 4,
-        },
-        {
-          authorization: 'Bearer valid-token',
-        }
-      ) as unknown as NextRequest;
-
-      // Mock user not found
-      vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
-
-      await POST(mockRequest);
-
-      expect(prisma.user.findUnique).toHaveBeenCalledWith({
-        where: { id: 'user_123' },
-      });
-      expect(NextResponse.json).toHaveBeenCalledWith(
-        { error: 'User not found' },
-        { status: 404 }
+        })
       );
     });
 
     it('should create a new rating and trigger place details fetch if place does not exist', async () => {
-      const mockRequest = new MockNextRequest(
+      const mockRequest = new NextRequest(
+        'http://localhost/api/places/rating',
         {
-          placeId: 'place_123',
-          rating: 4,
-        },
-        {
-          authorization: 'Bearer valid-token',
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer valid-token',
+          },
+          body: JSON.stringify({ placeId: mockPlaceId, rating: 4 }),
         }
-      ) as unknown as NextRequest;
+      );
 
       // Mock user found
       vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser);
@@ -304,55 +291,55 @@ describe('Rating API Routes', () => {
       const mockRating = createMockRating(4);
       vi.mocked(prisma.rating.create).mockResolvedValue(mockRating);
 
-      await POST(mockRequest);
+      const response = await POST(mockRequest);
+      const body = await getResponseBody(response);
 
       expect(prisma.user.findUnique).toHaveBeenCalledWith({
-        where: { id: 'user_123' },
+        where: { id: mockUserId },
       });
       expect(prisma.place.findUnique).toHaveBeenCalledWith({
-        where: { id: 'place_123' },
+        where: { id: mockPlaceId },
       });
       expect(inngest.send).toHaveBeenCalledWith({
         name: 'places/get-details',
         data: {
-          id: 'place_123',
+          id: mockPlaceId,
         },
       });
       expect(prisma.rating.findUnique).toHaveBeenCalledWith({
         where: {
           userId_placeId: {
-            userId: 'user_123',
-            placeId: 'place_123',
+            userId: mockUserId,
+            placeId: mockPlaceId,
           },
         },
       });
       expect(prisma.rating.create).toHaveBeenCalledWith({
         data: {
-          userId: 'user_123',
-          placeId: 'place_123',
+          userId: mockUserId,
+          placeId: mockPlaceId,
           rating: 4,
         },
       });
-      expect(NextResponse.json).toHaveBeenCalledWith(
-        {
-          message: 'Rating added',
-          rating: mockRating,
-          action: 'added',
-        },
-        { status: 200 }
-      );
+      expect(body).toEqual({
+        message: 'Rating added',
+        rating: mockRating,
+        action: 'added',
+      });
+      expect(response.status).toBe(200);
     });
 
     it('should update an existing rating', async () => {
-      const mockRequest = new MockNextRequest(
+      const mockRequest = new NextRequest(
+        'http://localhost/api/places/rating',
         {
-          placeId: 'place_123',
-          rating: 5,
-        },
-        {
-          authorization: 'Bearer valid-token',
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer valid-token',
+          },
+          body: JSON.stringify({ placeId: mockPlaceId, rating: 5 }),
         }
-      ) as unknown as NextRequest;
+      );
 
       // Mock user found
       vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser);
@@ -368,32 +355,32 @@ describe('Rating API Routes', () => {
       const updatedRating = createMockRating(5);
       vi.mocked(prisma.rating.update).mockResolvedValue(updatedRating);
 
-      await POST(mockRequest);
+      const response = await POST(mockRequest);
+      const body = await getResponseBody(response);
 
       expect(prisma.rating.update).toHaveBeenCalledWith({
-        where: { id: 'rating_123' },
+        where: { id: mockRatingId },
         data: { rating: 5 },
       });
-      expect(NextResponse.json).toHaveBeenCalledWith(
-        {
-          message: 'Rating updated',
-          rating: updatedRating,
-          action: 'updated',
-        },
-        { status: 200 }
-      );
+      expect(body).toEqual({
+        message: 'Rating updated',
+        rating: updatedRating,
+        action: 'updated',
+      });
+      expect(response.status).toBe(200);
     });
 
     it('should remove a rating if the same rating is submitted again', async () => {
-      const mockRequest = new MockNextRequest(
+      const mockRequest = new NextRequest(
+        'http://localhost/api/places/rating',
         {
-          placeId: 'place_123',
-          rating: 4, // Same as existing rating
-        },
-        {
-          authorization: 'Bearer valid-token',
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer valid-token',
+          },
+          body: JSON.stringify({ placeId: mockPlaceId, rating: 4 }),
         }
-      ) as unknown as NextRequest;
+      );
 
       // Mock user found
       vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser);
@@ -408,43 +395,186 @@ describe('Rating API Routes', () => {
       // Mock rating deletion
       vi.mocked(prisma.rating.delete).mockResolvedValue(existingRating);
 
-      await POST(mockRequest);
+      const response = await POST(mockRequest);
+      const body = await getResponseBody(response);
 
       expect(prisma.rating.delete).toHaveBeenCalledWith({
-        where: { id: 'rating_123' },
+        where: { id: mockRatingId },
       });
-      expect(NextResponse.json).toHaveBeenCalledWith(
-        {
-          message: 'Rating removed',
-          rating: existingRating,
-          action: 'removed',
-        },
-        { status: 200 }
-      );
+      expect(body).toEqual({
+        message: 'Rating removed',
+        rating: existingRating,
+        action: 'removed',
+      });
+      expect(response.status).toBe(200);
     });
 
     it('should handle errors and return 500 status', async () => {
-      const mockRequest = new MockNextRequest(
+      const mockRequest = new NextRequest(
+        'http://localhost/api/places/rating',
         {
-          placeId: 'place_123',
-          rating: 4,
-        },
-        {
-          authorization: 'Bearer valid-token',
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer valid-token',
+          },
+          body: JSON.stringify({ placeId: mockPlaceId, rating: 4 }),
         }
-      ) as unknown as NextRequest;
+      );
 
       // Mock database error
       vi.mocked(prisma.user.findUnique).mockRejectedValue(
         new Error('Database error')
       );
 
-      await POST(mockRequest);
+      const response = await POST(mockRequest);
+      const body = await getResponseBody(response);
 
-      expect(NextResponse.json).toHaveBeenCalledWith(
-        { error: 'Failed to process rating' },
-        { status: 500 }
+      expect(body).toEqual({ error: 'Failed to process rating' });
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe('GET /api/places/rating', () => {
+    it('should handle case where user is not authenticated', async () => {
+      // Mock getUserId to throw an unauthorized error
+      vi.mocked(getUserId).mockRejectedValueOnce(new Error('Unauthorized'));
+
+      const request = new NextRequest(
+        'http://localhost/api/places/favorite?id=place123',
+        {
+          headers: {
+            Authorization: 'Bearer test-token',
+          },
+        }
       );
+
+      const response = await GET(request);
+      const body = await getResponseBody(response);
+
+      expect(response.status).toBe(500);
+      expect(body).toEqual({ error: 'Failed to get rating' });
+    });
+
+    it('should return 400 if place ID is missing', async () => {
+      const request = new NextRequest('http://localhost/api/places/rating');
+
+      const response = await GET(request);
+      const body = await getResponseBody(response);
+
+      expect(response.status).toBe(400);
+      expect(body).toEqual({ error: 'Place ID is required' });
+    });
+
+    it('should return 404 if user is not found', async () => {
+      // Mock user not found
+      vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(null);
+
+      const request = new NextRequest(
+        'http://localhost/api/places/rating?id=place123'
+      );
+
+      const response = await GET(request);
+      const body = await getResponseBody(response);
+
+      expect(response.status).toBe(404);
+      expect(body).toEqual({ error: 'User not found' });
+    });
+
+    it('should handle case where place does not exist', async () => {
+      // Mock user found
+      vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(mockUser);
+
+      // Mock place not found
+      vi.mocked(prisma.place.findUnique).mockResolvedValueOnce(null);
+
+      const request = new NextRequest(
+        'http://localhost/api/places/rating?id=place123'
+      );
+
+      const response = await GET(request);
+      const body = await getResponseBody(response);
+
+      expect(response.status).toBe(404);
+      expect(body).toEqual({
+        error: 'Place not found',
+      });
+    });
+
+    it('should return rating=null if place exists but is not rated', async () => {
+      // Mock user found
+      vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(mockUser);
+
+      // Mock place found
+      vi.mocked(prisma.place.findUnique).mockResolvedValueOnce(mockPlace);
+
+      // Mock no rating found
+      vi.mocked(prisma.rating.findUnique).mockResolvedValueOnce(null);
+
+      const request = new NextRequest(
+        'http://localhost/api/places/rating?id=place123',
+        {
+          headers: {
+            Authorization: 'Bearer test-token',
+          },
+        }
+      );
+
+      const response = await GET(request);
+      const body = await getResponseBody(response);
+
+      expect(response.status).toBe(200);
+      expect(body).toEqual({
+        rating: null,
+      });
+    });
+
+    it('should return rating if place is rated', async () => {
+      // Mock user found
+      vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(mockUser);
+
+      // Mock place found
+      vi.mocked(prisma.place.findUnique).mockResolvedValueOnce(mockPlace);
+
+      // Mock rating found (rated 1 star)
+      vi.mocked(prisma.rating.findUnique).mockResolvedValueOnce(
+        createMockRating(1)
+      );
+
+      const request = new NextRequest(
+        'http://localhost/api/places/rating?id=place123',
+        {
+          headers: {
+            Authorization: 'Bearer test-token',
+          },
+        }
+      );
+
+      const response = await GET(request);
+      const body = await getResponseBody(response);
+
+      expect(response.status).toBe(200);
+      expect(body).toEqual({
+        rating: createMockRating(1).rating,
+      });
+    });
+
+    it('should handle server errors', async () => {
+      // Mock user found but then throw an error
+      vi.mocked(prisma.user.findUnique).mockRejectedValueOnce(
+        new Error('Database error')
+      );
+
+      const request = new NextRequest(
+        'http://localhost/api/places/rating?id=place123'
+      );
+
+      const response = await GET(request);
+      const body = await getResponseBody(response);
+
+      expect(response.status).toBe(500);
+      expect(body).toEqual({
+        error: 'Failed to get rating',
+      });
     });
   });
 });

--- a/src/app/admin/api-reference/places/details/page.tsx
+++ b/src/app/admin/api-reference/places/details/page.tsx
@@ -241,6 +241,9 @@ function DetailsForm() {
         }
       );
 
+      // Invalidate user query
+      queryClient.invalidateQueries({ queryKey: ['user'] });
+
       toast.success(`Place ${oldStatus ? 'unfavorited' : 'favorited'}`);
     },
     onError: (error) => {
@@ -277,6 +280,9 @@ function DetailsForm() {
           rating: rating === oldData.rating ? null : rating,
         })
       );
+
+      // Invalidate user query
+      queryClient.invalidateQueries({ queryKey: ['user'] });
 
       toast.success(`Place rating updated`);
     },
@@ -394,21 +400,16 @@ function DetailsForm() {
           <Star
             key={rating}
             className={cn(`
-                h-4 w-4 cursor-pointer transition-colors
-
-                ${
-                  isDisabled
-                    ? 'cursor-not-allowed animate-pulse'
-                    : 'cursor-pointer'
-                }
-                  
-
-                ${
-                  rating <= displayRating
-                    ? 'fill-yellow-400 text-yellow-400'
-                    : 'fill-none text-gray-300'
-                }
-                `)}
+              h-4 w-4 cursor-pointer transition-colors
+              ${isDisabled
+                ? 'cursor-not-allowed animate-pulse'
+                : 'cursor-pointer'
+              }
+              ${rating <= displayRating
+                ? 'fill-yellow-400 text-yellow-400'
+                : 'fill-none text-gray-300'
+              }
+            `)}
             onMouseEnter={() => setHoverRating(rating)}
             onMouseLeave={() => setHoverRating(null)}
             onClick={() => {
@@ -547,8 +548,8 @@ function DetailsForm() {
                   {toggleFavoriteMutation.isPending
                     ? 'Updating...'
                     : favoriteStatusQuery.data?.isFavorite
-                    ? 'Unfavorite'
-                    : 'Favorite'}
+                      ? 'Unfavorite'
+                      : 'Favorite'}
                 </Button>
 
                 {/* Photos Button */}
@@ -746,16 +747,15 @@ function DetailsForm() {
                                       {[1, 2, 3, 4, 5].map((star) => (
                                         <span
                                           key={`rating-star-${star}`}
-                                          className={`text-xl ${
-                                            (placeDetailsQuery.data.data
-                                              .rating || 0) >= star
-                                              ? 'text-yellow-400'
-                                              : (placeDetailsQuery.data.data
-                                                  .rating || 0) >=
-                                                star - 0.5
+                                          className={`text-xl ${(placeDetailsQuery.data.data
+                                            .rating || 0) >= star
+                                            ? 'text-yellow-400'
+                                            : (placeDetailsQuery.data.data
+                                              .rating || 0) >=
+                                              star - 0.5
                                               ? 'text-yellow-400/70'
                                               : 'text-gray-300'
-                                          }`}
+                                            }`}
                                         >
                                           ★
                                         </span>
@@ -776,7 +776,7 @@ function DetailsForm() {
                                   </span>
                                   <div className='text-right max-w-[60%]'>
                                     {placeDetailsQuery.data.data.priceLevel ===
-                                    null ? (
+                                      null ? (
                                       <span>Not specified</span>
                                     ) : (
                                       <span>
@@ -928,7 +928,7 @@ function DetailsForm() {
                             {/* Reviews section */}
                             {placeDetailsQuery.data.data.reviews &&
                               placeDetailsQuery.data.data.reviews.length >
-                                0 && (
+                              0 && (
                                 <div className='p-3 border rounded-md bg-muted/30'>
                                   <p className='text-sm font-medium mb-3'>
                                     Reviews:
@@ -945,11 +945,10 @@ function DetailsForm() {
                                               {[1, 2, 3, 4, 5].map((star) => (
                                                 <span
                                                   key={`review-star-${index}-${star}`}
-                                                  className={`text-xl ${
-                                                    review.rating >= star
-                                                      ? 'text-yellow-400'
-                                                      : 'text-gray-300'
-                                                  }`}
+                                                  className={`text-xl ${review.rating >= star
+                                                    ? 'text-yellow-400'
+                                                    : 'text-gray-300'
+                                                    }`}
                                                 >
                                                   ★
                                                 </span>

--- a/src/app/admin/api-reference/places/details/page.tsx
+++ b/src/app/admin/api-reference/places/details/page.tsx
@@ -539,7 +539,7 @@ function DetailsForm() {
                                 )}
                                 {renderDetailField(
                                   'Address',
-                                  placeDetailsQuery.data.data.formattedAddress
+                                  placeDetailsQuery.data.data.address
                                 )}
                                 {renderDetailField(
                                   'Latitude',
@@ -772,12 +772,7 @@ function DetailsForm() {
                                               'Unknown date'}
                                           </p>
                                           <p className='text-sm'>
-                                            {typeof review.text === 'object' &&
-                                            review.text?.text
-                                              ? review.text.text
-                                              : typeof review.text === 'string'
-                                              ? review.text
-                                              : 'No review text'}
+                                            {review.text}
                                           </p>
                                         </div>
                                       )

--- a/src/app/admin/api-reference/places/details/page.tsx
+++ b/src/app/admin/api-reference/places/details/page.tsx
@@ -241,9 +241,7 @@ function DetailsForm() {
         }
       );
 
-      toast.success(
-        `Place ${oldStatus ? 'unfavorited' : 'favorited'}`
-      );
+      toast.success(`Place ${oldStatus ? 'unfavorited' : 'favorited'}`);
     },
     onError: (error) => {
       toast.error(`Failed to update favorite: ${error.message}`);
@@ -280,9 +278,7 @@ function DetailsForm() {
         })
       );
 
-      toast.success(
-        `Place rating updated`
-      );
+      toast.success(`Place rating updated`);
     },
     onError: (error) => {
       toast.error(`Failed to update rating: ${error.message}`);
@@ -400,16 +396,18 @@ function DetailsForm() {
             className={cn(`
                 h-4 w-4 cursor-pointer transition-colors
 
-                ${isDisabled
-                ? 'cursor-not-allowed animate-pulse'
-                : 'cursor-pointer'
-              }
+                ${
+                  isDisabled
+                    ? 'cursor-not-allowed animate-pulse'
+                    : 'cursor-pointer'
+                }
                   
 
-                ${rating <= displayRating
-                ? 'fill-yellow-400 text-yellow-400'
-                : 'fill-none text-gray-300'
-              }
+                ${
+                  rating <= displayRating
+                    ? 'fill-yellow-400 text-yellow-400'
+                    : 'fill-none text-gray-300'
+                }
                 `)}
             onMouseEnter={() => setHoverRating(rating)}
             onMouseLeave={() => setHoverRating(null)}
@@ -549,8 +547,8 @@ function DetailsForm() {
                   {toggleFavoriteMutation.isPending
                     ? 'Updating...'
                     : favoriteStatusQuery.data?.isFavorite
-                      ? 'Unfavorite'
-                      : 'Favorite'}
+                    ? 'Unfavorite'
+                    : 'Favorite'}
                 </Button>
 
                 {/* Photos Button */}
@@ -748,15 +746,16 @@ function DetailsForm() {
                                       {[1, 2, 3, 4, 5].map((star) => (
                                         <span
                                           key={`rating-star-${star}`}
-                                          className={`text-xl ${(placeDetailsQuery.data.data
-                                            .rating || 0) >= star
-                                            ? 'text-yellow-400'
-                                            : (placeDetailsQuery.data.data
-                                              .rating || 0) >=
-                                              star - 0.5
+                                          className={`text-xl ${
+                                            (placeDetailsQuery.data.data
+                                              .rating || 0) >= star
+                                              ? 'text-yellow-400'
+                                              : (placeDetailsQuery.data.data
+                                                  .rating || 0) >=
+                                                star - 0.5
                                               ? 'text-yellow-400/70'
                                               : 'text-gray-300'
-                                            }`}
+                                          }`}
                                         >
                                           ★
                                         </span>
@@ -777,7 +776,7 @@ function DetailsForm() {
                                   </span>
                                   <div className='text-right max-w-[60%]'>
                                     {placeDetailsQuery.data.data.priceLevel ===
-                                      null ? (
+                                    null ? (
                                       <span>Not specified</span>
                                     ) : (
                                       <span>
@@ -929,7 +928,7 @@ function DetailsForm() {
                             {/* Reviews section */}
                             {placeDetailsQuery.data.data.reviews &&
                               placeDetailsQuery.data.data.reviews.length >
-                              0 && (
+                                0 && (
                                 <div className='p-3 border rounded-md bg-muted/30'>
                                   <p className='text-sm font-medium mb-3'>
                                     Reviews:
@@ -946,10 +945,11 @@ function DetailsForm() {
                                               {[1, 2, 3, 4, 5].map((star) => (
                                                 <span
                                                   key={`review-star-${index}-${star}`}
-                                                  className={`text-xl ${review.rating >= star
-                                                    ? 'text-yellow-400'
-                                                    : 'text-gray-300'
-                                                    }`}
+                                                  className={`text-xl ${
+                                                    review.rating >= star
+                                                      ? 'text-yellow-400'
+                                                      : 'text-gray-300'
+                                                  }`}
                                                 >
                                                   ★
                                                 </span>

--- a/src/app/admin/api-reference/places/details/page.tsx
+++ b/src/app/admin/api-reference/places/details/page.tsx
@@ -401,13 +401,15 @@ function DetailsForm() {
             key={rating}
             className={cn(`
               h-4 w-4 cursor-pointer transition-colors
-              ${isDisabled
-                ? 'cursor-not-allowed animate-pulse'
-                : 'cursor-pointer'
+              ${
+                isDisabled
+                  ? 'cursor-not-allowed animate-pulse'
+                  : 'cursor-pointer'
               }
-              ${rating <= displayRating
-                ? 'fill-yellow-400 text-yellow-400'
-                : 'fill-none text-gray-300'
+              ${
+                rating <= displayRating
+                  ? 'fill-yellow-400 text-yellow-400'
+                  : 'fill-none text-gray-300'
               }
             `)}
             onMouseEnter={() => setHoverRating(rating)}
@@ -548,8 +550,8 @@ function DetailsForm() {
                   {toggleFavoriteMutation.isPending
                     ? 'Updating...'
                     : favoriteStatusQuery.data?.isFavorite
-                      ? 'Unfavorite'
-                      : 'Favorite'}
+                    ? 'Unfavorite'
+                    : 'Favorite'}
                 </Button>
 
                 {/* Photos Button */}
@@ -747,15 +749,16 @@ function DetailsForm() {
                                       {[1, 2, 3, 4, 5].map((star) => (
                                         <span
                                           key={`rating-star-${star}`}
-                                          className={`text-xl ${(placeDetailsQuery.data.data
-                                            .rating || 0) >= star
-                                            ? 'text-yellow-400'
-                                            : (placeDetailsQuery.data.data
-                                              .rating || 0) >=
-                                              star - 0.5
+                                          className={`text-xl ${
+                                            (placeDetailsQuery.data.data
+                                              .rating || 0) >= star
+                                              ? 'text-yellow-400'
+                                              : (placeDetailsQuery.data.data
+                                                  .rating || 0) >=
+                                                star - 0.5
                                               ? 'text-yellow-400/70'
                                               : 'text-gray-300'
-                                            }`}
+                                          }`}
                                         >
                                           ★
                                         </span>
@@ -776,7 +779,7 @@ function DetailsForm() {
                                   </span>
                                   <div className='text-right max-w-[60%]'>
                                     {placeDetailsQuery.data.data.priceLevel ===
-                                      null ? (
+                                    null ? (
                                       <span>Not specified</span>
                                     ) : (
                                       <span>
@@ -928,7 +931,7 @@ function DetailsForm() {
                             {/* Reviews section */}
                             {placeDetailsQuery.data.data.reviews &&
                               placeDetailsQuery.data.data.reviews.length >
-                              0 && (
+                                0 && (
                                 <div className='p-3 border rounded-md bg-muted/30'>
                                   <p className='text-sm font-medium mb-3'>
                                     Reviews:
@@ -945,10 +948,11 @@ function DetailsForm() {
                                               {[1, 2, 3, 4, 5].map((star) => (
                                                 <span
                                                   key={`review-star-${index}-${star}`}
-                                                  className={`text-xl ${review.rating >= star
-                                                    ? 'text-yellow-400'
-                                                    : 'text-gray-300'
-                                                    }`}
+                                                  className={`text-xl ${
+                                                    review.rating >= star
+                                                      ? 'text-yellow-400'
+                                                      : 'text-gray-300'
+                                                  }`}
                                                 >
                                                   ★
                                                 </span>

--- a/src/app/admin/api-reference/places/details/page.tsx
+++ b/src/app/admin/api-reference/places/details/page.tsx
@@ -228,9 +228,22 @@ function DetailsForm() {
       return response.json();
     },
     onSuccess: () => {
-      // Invalidate both queries to refetch latest data
-      queryClient.invalidateQueries({ queryKey: ['favoriteStatus', placeId] });
-      toast.success('Favorite status updated');
+      let oldStatus;
+      // Update the favorite status query cache
+      queryClient.setQueryData(
+        ['favoriteStatus', placeId],
+        (oldData: { isFavorite: boolean }) => {
+          oldStatus = oldData.isFavorite;
+          return {
+            ...oldData,
+            isFavorite: !oldData.isFavorite,
+          };
+        }
+      );
+
+      toast.success(
+        `Place ${oldStatus ? 'unfavorited' : 'favorited'}`
+      );
     },
     onError: (error) => {
       toast.error(`Failed to update favorite: ${error.message}`);
@@ -267,10 +280,12 @@ function DetailsForm() {
         })
       );
 
-      toast.success('Favorite status updated');
+      toast.success(
+        `Place rating updated`
+      );
     },
     onError: (error) => {
-      toast.error(`Failed to update favorite: ${error.message}`);
+      toast.error(`Failed to update rating: ${error.message}`);
     },
   });
 
@@ -385,18 +400,16 @@ function DetailsForm() {
             className={cn(`
                 h-4 w-4 cursor-pointer transition-colors
 
-                ${
-                  isDisabled
-                    ? 'cursor-not-allowed animate-pulse'
-                    : 'cursor-pointer'
-                }
+                ${isDisabled
+                ? 'cursor-not-allowed animate-pulse'
+                : 'cursor-pointer'
+              }
                   
 
-                ${
-                  rating <= displayRating
-                    ? 'fill-yellow-400 text-yellow-400'
-                    : 'fill-none text-gray-300'
-                }
+                ${rating <= displayRating
+                ? 'fill-yellow-400 text-yellow-400'
+                : 'fill-none text-gray-300'
+              }
                 `)}
             onMouseEnter={() => setHoverRating(rating)}
             onMouseLeave={() => setHoverRating(null)}
@@ -536,8 +549,8 @@ function DetailsForm() {
                   {toggleFavoriteMutation.isPending
                     ? 'Updating...'
                     : favoriteStatusQuery.data?.isFavorite
-                    ? 'Unfavorite'
-                    : 'Favorite'}
+                      ? 'Unfavorite'
+                      : 'Favorite'}
                 </Button>
 
                 {/* Photos Button */}
@@ -735,16 +748,15 @@ function DetailsForm() {
                                       {[1, 2, 3, 4, 5].map((star) => (
                                         <span
                                           key={`rating-star-${star}`}
-                                          className={`text-xl ${
-                                            (placeDetailsQuery.data.data
-                                              .rating || 0) >= star
-                                              ? 'text-yellow-400'
-                                              : (placeDetailsQuery.data.data
-                                                  .rating || 0) >=
-                                                star - 0.5
+                                          className={`text-xl ${(placeDetailsQuery.data.data
+                                            .rating || 0) >= star
+                                            ? 'text-yellow-400'
+                                            : (placeDetailsQuery.data.data
+                                              .rating || 0) >=
+                                              star - 0.5
                                               ? 'text-yellow-400/70'
                                               : 'text-gray-300'
-                                          }`}
+                                            }`}
                                         >
                                           ★
                                         </span>
@@ -765,7 +777,7 @@ function DetailsForm() {
                                   </span>
                                   <div className='text-right max-w-[60%]'>
                                     {placeDetailsQuery.data.data.priceLevel ===
-                                    null ? (
+                                      null ? (
                                       <span>Not specified</span>
                                     ) : (
                                       <span>
@@ -917,7 +929,7 @@ function DetailsForm() {
                             {/* Reviews section */}
                             {placeDetailsQuery.data.data.reviews &&
                               placeDetailsQuery.data.data.reviews.length >
-                                0 && (
+                              0 && (
                                 <div className='p-3 border rounded-md bg-muted/30'>
                                   <p className='text-sm font-medium mb-3'>
                                     Reviews:
@@ -934,11 +946,10 @@ function DetailsForm() {
                                               {[1, 2, 3, 4, 5].map((star) => (
                                                 <span
                                                   key={`review-star-${index}-${star}`}
-                                                  className={`text-xl ${
-                                                    review.rating >= star
-                                                      ? 'text-yellow-400'
-                                                      : 'text-gray-300'
-                                                  }`}
+                                                  className={`text-xl ${review.rating >= star
+                                                    ? 'text-yellow-400'
+                                                    : 'text-gray-300'
+                                                    }`}
                                                 >
                                                   ★
                                                 </span>

--- a/src/app/admin/api-reference/places/details/page.tsx
+++ b/src/app/admin/api-reference/places/details/page.tsx
@@ -259,10 +259,13 @@ function DetailsForm() {
     },
     onSuccess: (_, rating) => {
       // Update the rating query cache
-      queryClient.setQueryData(['rating', placeId], (oldData: { rating: number | null }) => ({
-        ...oldData,
-        rating: rating === oldData.rating ? null : rating,
-      }));
+      queryClient.setQueryData(
+        ['rating', placeId],
+        (oldData: { rating: number | null }) => ({
+          ...oldData,
+          rating: rating === oldData.rating ? null : rating,
+        })
+      );
 
       toast.success('Favorite status updated');
     },
@@ -375,24 +378,26 @@ function DetailsForm() {
     const isDisabled = updateRatingMutation.isPending;
 
     return (
-      <div className="flex items-center gap-1 px-2 py-1 border rounded-md">
+      <div className='flex items-center gap-1 px-2 py-1 border rounded-md'>
         {[1, 2, 3, 4, 5].map((rating) => (
           <Star
             key={rating}
-            className={
-              cn(`
+            className={cn(`
                 h-4 w-4 cursor-pointer transition-colors
 
-                ${isDisabled ? 'cursor-not-allowed animate-pulse' : 'cursor-pointer'}
+                ${
+                  isDisabled
+                    ? 'cursor-not-allowed animate-pulse'
+                    : 'cursor-pointer'
+                }
                   
 
-                ${rating
-                  <= displayRating
-                  ? 'fill-yellow-400 text-yellow-400'
-                  : 'fill-none text-gray-300'
+                ${
+                  rating <= displayRating
+                    ? 'fill-yellow-400 text-yellow-400'
+                    : 'fill-none text-gray-300'
                 }
-                `)
-            }
+                `)}
             onMouseEnter={() => setHoverRating(rating)}
             onMouseLeave={() => setHoverRating(null)}
             onClick={() => {
@@ -504,7 +509,7 @@ function DetailsForm() {
       <Card>
         <CardHeader>
           <div className='flex justify-between items-center'>
-            <div className="space-y-1.5">
+            <div className='space-y-1.5'>
               <CardTitle>Details Results</CardTitle>
               <CardDescription>Place information and metadata</CardDescription>
             </div>
@@ -515,18 +520,24 @@ function DetailsForm() {
 
                 {/* Favorite Button */}
                 <Button
-                  variant={favoriteStatusQuery.data?.isFavorite ? 'destructive' : 'outline'}
+                  variant={
+                    favoriteStatusQuery.data?.isFavorite
+                      ? 'destructive'
+                      : 'outline'
+                  }
                   size='sm'
                   onClick={() => toggleFavoriteMutation.mutate()}
-                  disabled={!placeDetailsQuery.data.data?.id || toggleFavoriteMutation.isPending || favoriteStatusQuery.isLoading}
+                  disabled={
+                    !placeDetailsQuery.data.data?.id ||
+                    toggleFavoriteMutation.isPending ||
+                    favoriteStatusQuery.isLoading
+                  }
                 >
-                  {toggleFavoriteMutation.isPending ? (
-                    'Updating...'
-                  ) : favoriteStatusQuery.data?.isFavorite ? (
-                    'Unfavorite'
-                  ) : (
-                    'Favorite'
-                  )}
+                  {toggleFavoriteMutation.isPending
+                    ? 'Updating...'
+                    : favoriteStatusQuery.data?.isFavorite
+                    ? 'Unfavorite'
+                    : 'Favorite'}
                 </Button>
 
                 {/* Photos Button */}
@@ -724,15 +735,16 @@ function DetailsForm() {
                                       {[1, 2, 3, 4, 5].map((star) => (
                                         <span
                                           key={`rating-star-${star}`}
-                                          className={`text-xl ${(placeDetailsQuery.data.data
-                                            .rating || 0) >= star
-                                            ? 'text-yellow-400'
-                                            : (placeDetailsQuery.data.data
-                                              .rating || 0) >=
-                                              star - 0.5
+                                          className={`text-xl ${
+                                            (placeDetailsQuery.data.data
+                                              .rating || 0) >= star
+                                              ? 'text-yellow-400'
+                                              : (placeDetailsQuery.data.data
+                                                  .rating || 0) >=
+                                                star - 0.5
                                               ? 'text-yellow-400/70'
                                               : 'text-gray-300'
-                                            }`}
+                                          }`}
                                         >
                                           ★
                                         </span>
@@ -753,7 +765,7 @@ function DetailsForm() {
                                   </span>
                                   <div className='text-right max-w-[60%]'>
                                     {placeDetailsQuery.data.data.priceLevel ===
-                                      null ? (
+                                    null ? (
                                       <span>Not specified</span>
                                     ) : (
                                       <span>
@@ -905,7 +917,7 @@ function DetailsForm() {
                             {/* Reviews section */}
                             {placeDetailsQuery.data.data.reviews &&
                               placeDetailsQuery.data.data.reviews.length >
-                              0 && (
+                                0 && (
                                 <div className='p-3 border rounded-md bg-muted/30'>
                                   <p className='text-sm font-medium mb-3'>
                                     Reviews:
@@ -922,10 +934,11 @@ function DetailsForm() {
                                               {[1, 2, 3, 4, 5].map((star) => (
                                                 <span
                                                   key={`review-star-${index}-${star}`}
-                                                  className={`text-xl ${review.rating >= star
-                                                    ? 'text-yellow-400'
-                                                    : 'text-gray-300'
-                                                    }`}
+                                                  className={`text-xl ${
+                                                    review.rating >= star
+                                                      ? 'text-yellow-400'
+                                                      : 'text-gray-300'
+                                                  }`}
                                                 >
                                                   ★
                                                 </span>

--- a/src/app/api/admin/user-favorites/route.ts
+++ b/src/app/api/admin/user-favorites/route.ts
@@ -36,7 +36,7 @@ export async function GET(
         place: {
           select: {
             name: true,
-            description: true,
+            editorialSummary: true,
           },
         },
       },

--- a/src/app/api/admin/user-ratings/route.ts
+++ b/src/app/api/admin/user-ratings/route.ts
@@ -36,7 +36,7 @@ export async function GET(
         place: {
           select: {
             name: true,
-            description: true,
+            editorialSummary: true,
           },
         },
       },

--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -1,8 +1,8 @@
 import { serve } from 'inngest/next';
 import { inngest } from '@/inngest/client';
-import { upsertPlace } from '@/inngest/functions';
+import { createPlace, getPlaceDetails } from '@/inngest/functions';
 
 export const { GET, POST, PUT } = serve({
   client: inngest,
-  functions: [upsertPlace],
+  functions: [createPlace, getPlaceDetails],
 });

--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -1,8 +1,8 @@
 import { serve } from 'inngest/next';
 import { inngest } from '@/inngest/client';
-import { createPlace, getPlaceDetails } from '@/inngest/functions';
+import { createPlace } from '@/inngest/functions';
 
 export const { GET, POST, PUT } = serve({
   client: inngest,
-  functions: [createPlace, getPlaceDetails],
+  functions: [createPlace],
 });

--- a/src/app/api/merchant/associate/route.ts
+++ b/src/app/api/merchant/associate/route.ts
@@ -99,26 +99,45 @@ export async function POST(request: NextRequest) {
         place = await tx.place.upsert({
           where: { id: placeId },
           create: {
-            id: placeId,
-            name: placeDetails.displayName,
-            description: placeDetails.editorialSummary,
-            latitude: placeDetails.location.latitude,
-            longitude: placeDetails.location.longitude,
+            id: placeDetails.id,
+            name: placeDetails.name,
+            latitude: placeDetails.latitude,
+            longitude: placeDetails.longitude,
+            address: placeDetails.address,
+            merchantId: null,
+            allowsDogs: placeDetails.allowsDogs,
+            delivery: placeDetails.delivery,
+            editorialSummary: placeDetails.editorialSummary,
+            generativeSummary: placeDetails.generativeSummary,
+            goodForChildren: placeDetails.goodForChildren,
+            dineIn: placeDetails.dineIn,
+            goodForGroups: placeDetails.goodForGroups,
+            isFree: placeDetails.isFree,
+            liveMusic: placeDetails.liveMusic,
+            menuForChildren: placeDetails.menuForChildren,
+            outdoorSeating: placeDetails.outdoorSeating,
+            acceptsCashOnly: placeDetails.acceptsCashOnly,
+            acceptsCreditCards: placeDetails.acceptsCreditCards,
+            acceptsDebitCards: placeDetails.acceptsDebitCards,
+            priceLevel: placeDetails.priceLevel,
+            primaryTypeDisplayName: placeDetails.primaryTypeDisplayName,
+            googleRating: placeDetails.googleRating,
+            servesCoffee: placeDetails.servesCoffee,
+            servesDessert: placeDetails.servesDessert,
+            takeout: placeDetails.takeout,
+            restroom: placeDetails.restroom,
+            openNow: placeDetails.openNow,
+            userRatingCount: placeDetails.userRatingCount,
             reviews: {
               createMany: {
-                data: placeDetails.reviews
-                  .map((review) => ({
-                    name: review.name,
-                    relativePublishTimeDescription:
-                      review.relativePublishTimeDescription,
-                    rating: review.rating,
-                    text: review.text?.text || '',
-                  }))
-                  .filter((review) => Boolean(review.text)),
+                data: placeDetails.reviews.map((review) => ({
+                  ...review,
+                  placeId: placeDetails.id,
+                })),
               },
             },
           },
-          update: {}, // No updates needed if it exists
+          update: {},
           include: {
             photos: true,
             ratings: true,

--- a/src/app/api/places/details/route.ts
+++ b/src/app/api/places/details/route.ts
@@ -16,7 +16,7 @@ export async function GET(
     // Send event to create place if it doesn't exist
     // without blocking the response
     inngest.send({
-      name: 'places/upsert',
+      name: 'places/create',
       data: {
         id,
         details,

--- a/src/app/api/places/photos/route.ts
+++ b/src/app/api/places/photos/route.ts
@@ -60,3 +60,5 @@ export const config = {
     bodyParser: false,
   },
 };
+
+// TODO: cache photos by place id

--- a/src/app/merchant/dashboard/page.tsx
+++ b/src/app/merchant/dashboard/page.tsx
@@ -196,7 +196,9 @@ export default function MerchantDashboard() {
                     <div className='flex items-center gap-2'>
                       <MapPin className='h-4 w-4 text-muted-foreground' />
                       <p className='text-sm text-muted-foreground'>
-                        {place.description}
+                        {place.editorialSummary ||
+                          place.generativeSummary ||
+                          'No description available'}
                       </p>
                     </div>
                     {place.address && (

--- a/src/components/user-details-dialog.tsx
+++ b/src/components/user-details-dialog.tsx
@@ -203,10 +203,12 @@ export function UserDetailsDialog({
                               {favorite.place.name || 'Unnamed place'}
                             </TableCell>
                             <TableCell>
-                              {favorite.place.description?.substring(0, 100) ||
-                                'No description'}
-                              {favorite.place.description &&
-                                favorite.place.description.length > 100 &&
+                              {favorite.place.editorialSummary?.substring(
+                                0,
+                                100
+                              ) || 'No description'}
+                              {favorite.place.editorialSummary &&
+                                favorite.place.editorialSummary.length > 100 &&
                                 '...'}
                             </TableCell>
                             <TableCell>
@@ -272,10 +274,12 @@ export function UserDetailsDialog({
                               </div>
                             </TableCell>
                             <TableCell>
-                              {rating.place.description?.substring(0, 100) ||
-                                'No description'}
-                              {rating.place.description &&
-                                rating.place.description.length > 100 &&
+                              {rating.place.editorialSummary?.substring(
+                                0,
+                                100
+                              ) || 'No description'}
+                              {rating.place.editorialSummary &&
+                                rating.place.editorialSummary.length > 100 &&
                                 '...'}
                             </TableCell>
                             <TableCell>

--- a/src/inngest/client.ts
+++ b/src/inngest/client.ts
@@ -8,15 +8,8 @@ type PlaceCreate = {
   };
 };
 
-type PlaceGetDetails = {
-  data: {
-    id: string;
-  };
-};
-
 type Events = {
   'places/create': PlaceCreate;
-  'places/get-details': PlaceGetDetails;
 };
 
 export const inngest = new Inngest({

--- a/src/inngest/client.ts
+++ b/src/inngest/client.ts
@@ -1,15 +1,22 @@
 import { EventSchemas, Inngest } from 'inngest';
 import type { DetailResponse } from '@/types/details';
 
-type PlaceUpsert = {
+type PlaceCreate = {
   data: {
     id: string;
     details: DetailResponse;
   };
 };
 
+type PlaceGetDetails = {
+  data: {
+    id: string;
+  };
+};
+
 type Events = {
-  'places/upsert': PlaceUpsert;
+  'places/create': PlaceCreate;
+  'places/get-details': PlaceGetDetails;
 };
 
 export const inngest = new Inngest({

--- a/src/inngest/functions.ts
+++ b/src/inngest/functions.ts
@@ -1,12 +1,81 @@
 import { prisma } from '@/lib/db';
+import { getPlaceDetailsWithCache } from '@/services/places/details/get-place-details-with-cache/get-place-details-with-cache';
 import { inngest } from './client';
 
-export const upsertPlace = inngest.createFunction(
-  { id: 'places/upsert' },
-  { event: 'places/upsert' },
+// Creates place in DB
+export const createPlace = inngest.createFunction(
+  { id: 'places/create' },
+  { event: 'places/create' },
   async ({ event }) => {
     const { id, details } = event.data;
 
+    let place = await prisma.place.findUnique({
+      where: {
+        id,
+      },
+    });
+
+    if (place) {
+      return { message: `Place ${id} already exists` };
+    }
+
+    place = await prisma.place.create({
+      data: {
+        id: details.data.id,
+        name: details.data.displayName,
+        latitude: details.data.location.latitude,
+        longitude: details.data.location.longitude,
+        address: details.data.address,
+        merchantId: null,
+        allowsDogs: details.data.allowsDogs,
+        delivery: details.data.delivery,
+        editorialSummary: details.data.editorialSummary,
+        generativeSummary: details.data.generativeSummary,
+        goodForChildren: details.data.goodForChildren,
+        dineIn: details.data.dineIn,
+        goodForGroups: details.data.goodForGroups,
+        isFree: details.data.isFree,
+        liveMusic: details.data.liveMusic,
+        menuForChildren: details.data.menuForChildren,
+        outdoorSeating: details.data.outdoorSeating,
+        acceptsCashOnly: details.data.acceptsCashOnly,
+        acceptsCreditCards: details.data.acceptsCreditCards,
+        acceptsDebitCards: details.data.acceptsDebitCards,
+        priceLevel: details.data.priceLevel,
+        primaryTypeDisplayName: details.data.primaryTypeDisplayName,
+        googleRating: details.data.rating,
+        servesCoffee: details.data.servesCoffee,
+        servesDessert: details.data.servesDessert,
+        takeout: details.data.takeout,
+        restroom: details.data.restroom,
+        openNow: details.data.openNow,
+        userRatingCount: details.data.userRatingCount,
+
+        reviews: {
+          createMany: {
+            data: details.data.reviews,
+          },
+        },
+      },
+    });
+
+    if (!place) {
+      return { message: `Place ${id} not created` };
+    }
+
+    return { message: `Place ${id} created` };
+  }
+);
+
+// Gets from Google API &
+// calls createPlace function
+export const getPlaceDetails = inngest.createFunction(
+  { id: 'places/get-details' },
+  { event: 'places/get-details' },
+  async ({ event }) => {
+    const { id } = event.data;
+
+    // Double check if place exists in DB
     const place = await prisma.place.findUnique({
       where: {
         id: id,
@@ -17,34 +86,13 @@ export const upsertPlace = inngest.createFunction(
       return { message: `Place ${id} already exists` };
     }
 
-    const googlePlaceDisplayName = details.data.displayName;
-    const googlePlaceEditorialSummary = details.data.editorialSummary;
-    const googlePlaceReviews = details.data.reviews
-      .map((review) => ({
-        name: review.name, // googles id for the review
-        relativePublishTimeDescription: review.relativePublishTimeDescription,
-        rating: review.rating,
-        text: review.text?.text ?? '',
-      }))
-      .filter((review) => Boolean(review.text && review.text.length > 0));
+    const details = await getPlaceDetailsWithCache({ id });
 
-    const latitude = details.data.location.latitude;
-    const longitude = details.data.location.longitude;
-    const formattedAddress = details.data.formattedAddress;
-
-    await prisma.place.create({
+    await inngest.send({
+      name: 'places/create',
       data: {
         id,
-        name: googlePlaceDisplayName,
-        description: googlePlaceEditorialSummary,
-        latitude: latitude,
-        longitude: longitude,
-        address: formattedAddress,
-        reviews: {
-          createMany: {
-            data: googlePlaceReviews,
-          },
-        },
+        details,
       },
     });
 

--- a/src/inngest/functions.ts
+++ b/src/inngest/functions.ts
@@ -19,6 +19,10 @@ export const createPlace = inngest.createFunction(
       return { message: `Place ${id} already exists` };
     }
 
+    if (!details.data) {
+      return { message: `Place ${id} details not found` };
+    }
+
     place = await prisma.place.create({
       data: {
         id: details.data.id,
@@ -50,17 +54,21 @@ export const createPlace = inngest.createFunction(
         restroom: details.data.restroom,
         openNow: details.data.openNow,
         userRatingCount: details.data.userRatingCount,
-
-        reviews: {
-          createMany: {
-            data: details.data.reviews,
-          },
-        },
       },
     });
 
     if (!place) {
       return { message: `Place ${id} not created` };
+    }
+
+    // TODO: create reviews
+    if (details.data.reviews) {
+      await prisma.review.createMany({
+        data: details.data.reviews.map((review) => ({
+          ...review,
+          placeId: place.id,
+        })),
+      });
     }
 
     return { message: `Place ${id} created` };

--- a/src/services/places/details/data-transformer/data-transformer.test.ts
+++ b/src/services/places/details/data-transformer/data-transformer.test.ts
@@ -1,116 +1,139 @@
+import { ReviewStatus } from '@prisma/client';
 import { describe, it, expect } from 'vitest';
 import { transformDetailsData } from './data-transformer';
+import { getReviewId } from '../get-review-id/get-review-id';
 import type { ValidatedGoogleDetailsResponse } from '../validator/details-validator';
 
 describe('data-transformer', () => {
   describe('transformDetailsData', () => {
     it('should transform a complete response correctly', () => {
       // Arrange
-      const mockData: ValidatedGoogleDetailsResponse = {
-        name: 'Test Restaurant',
+      const mockData = {
+        id: 'ChIJifIePKtZwokRVZ-UdRGkZzs',
+        name: 'places/ChIJifIePKtZwokRVZ-UdRGkZzs',
+        displayName: {
+          text: "Joe's Pizza Broadway",
+        },
+        primaryTypeDisplayName: {
+          text: 'Pizza Restaurant',
+        },
+        delivery: true,
+        dineIn: true,
+        goodForChildren: true,
+        restroom: false,
+        goodForGroups: true,
+        paymentOptions: {
+          acceptsCreditCards: true,
+          acceptsDebitCards: true,
+          acceptsCashOnly: false,
+        },
         reviews: [
           {
-            name: 'Review 1',
+            name: 'places/ChIJifIePKtZwokRVZ-UdRGkZzs/reviews/ChdDSUhNMG9nS0VJQ0FnTUR3eGREQzV3RRAB',
+            relativePublishTimeDescription: 'in the last week',
             rating: 5,
-            relativePublishTimeDescription: '2 days ago',
             text: {
-              text: 'Great place!',
+              text: "Came to Joe's Pizza in Times Square after hearing all the hype—and it absolutely lived up to it. The place was packed (as expected), but the line moved fast and the staff kept things flowing smoothly.\n\nI got a pepperoni slice with sausage, mushrooms, and red onions—super flavorful, thin crust, crispy on the edges, and not overly greasy. It had that perfect NYC street slice taste you hope for. Just classic and satisfying.\n\nThe vibe inside is pure New York: walls covered in celebrity photos, press clippings, and Spider-Man references. It feels like a piece of pizza history. Despite being in such a tourist-heavy area, Joe's still feels authentic and delivers the real deal.\n\nIf you're in NYC and want a proper slice, this is the spot. I'd definitely come back.",
               languageCode: 'en',
             },
             originalText: {
-              text: 'Great place!',
+              text: "Came to Joe's Pizza in Times Square after hearing all the hype—and it absolutely lived up to it. The place was packed (as expected), but the line moved fast and the staff kept things flowing smoothly.\n\nI got a pepperoni slice with sausage, mushrooms, and red onions—super flavorful, thin crust, crispy on the edges, and not overly greasy. It had that perfect NYC street slice taste you hope for. Just classic and satisfying.\n\nThe vibe inside is pure New York: walls covered in celebrity photos, press clippings, and Spider-Man references. It feels like a piece of pizza history. Despite being in such a tourist-heavy area, Joe's still feels authentic and delivers the real deal.\n\nIf you're in NYC and want a proper slice, this is the spot. I'd definitely come back.",
               languageCode: 'en',
             },
           },
         ],
         rating: 4.5,
-        priceLevel: 'PRICE_LEVEL_MODERATE',
-        userRatingCount: 100,
+        priceLevel: 'PRICE_LEVEL_INEXPENSIVE',
+        userRatingCount: 21260,
         currentOpeningHours: {
           openNow: true,
         },
-        displayName: {
-          text: 'Test Restaurant Display Name',
-        },
-        primaryTypeDisplayName: {
-          text: 'Restaurant',
-        },
         takeout: true,
-        delivery: false,
-        dineIn: true,
         editorialSummary: {
-          text: 'A great restaurant with amazing food',
+          text: 'Modern outpost of a longtime counter-serve pizza joint prepping New York-style slices and pies.',
         },
         outdoorSeating: true,
         liveMusic: false,
-        menuForChildren: true,
-        servesDessert: true,
-        servesCoffee: true,
-        goodForChildren: true,
-        goodForGroups: true,
-        allowsDogs: false,
-        restroom: true,
-        paymentOptions: {
-          acceptsCreditCards: true,
-          acceptsDebitCards: true,
-          acceptsCashOnly: false,
-        },
+        menuForChildren: false,
+        servesDessert: false,
+        servesCoffee: false,
         generativeSummary: {
           overview: {
-            text: 'This is a generative summary of the restaurant',
+            text: 'Casual spot offering many types of New York-style pizza, including by the slice, until late at night.',
           },
         },
         location: {
-          latitude: 37.7749,
-          longitude: -122.4194,
+          latitude: 40.754679499999995,
+          longitude: -73.9870291,
         },
-        formattedAddress: '123 Test St, San Francisco, CA 94105',
+        formattedAddress: '1435 Broadway, New York, NY 10018, USA',
       };
 
       // Act
-      const result = transformDetailsData(mockData);
+      const result = transformDetailsData(
+        mockData as ValidatedGoogleDetailsResponse
+      );
 
       // Assert
       expect(result).toEqual({
-        name: 'Test Restaurant',
-        reviews: mockData.reviews,
-        rating: 4.5,
-        priceLevel: 2, // PRICE_LEVEL_MODERATE maps to 2
-        userRatingCount: 100,
-        openNow: true,
-        displayName: 'Test Restaurant Display Name',
-        primaryTypeDisplayName: 'Restaurant',
-        takeout: true,
-        delivery: false,
-        dineIn: true,
-        editorialSummary: 'A great restaurant with amazing food',
-        outdoorSeating: true,
-        liveMusic: false,
-        menuForChildren: true,
-        servesDessert: true,
-        servesCoffee: true,
-        goodForChildren: true,
-        goodForGroups: true,
+        id: mockData.id,
+        name: mockData.displayName.text,
+        reviews: [
+          {
+            id: getReviewId(mockData.reviews[0].name),
+            placeId: mockData.id,
+            rating: mockData.reviews[0].rating,
+            relativePublishTimeDescription:
+              mockData.reviews[0].relativePublishTimeDescription,
+            status: ReviewStatus.DEFAULT,
+            text: mockData.reviews[0].text.text,
+          },
+        ],
+        rating: mockData.rating,
+        priceLevel: 1, // PRICE_LEVEL_INEXPENSIVE maps to 1
+        userRatingCount: mockData.userRatingCount,
+        openNow: mockData.currentOpeningHours.openNow,
+        displayName: mockData.displayName.text,
+        primaryTypeDisplayName: mockData.primaryTypeDisplayName.text,
+        takeout: mockData.takeout,
+        delivery: mockData.delivery,
+        dineIn: mockData.dineIn,
+        editorialSummary: mockData.editorialSummary.text,
+        outdoorSeating: mockData.outdoorSeating,
+        liveMusic: mockData.liveMusic,
+        menuForChildren: mockData.menuForChildren,
+        servesDessert: mockData.servesDessert,
+        servesCoffee: mockData.servesCoffee,
+        goodForChildren: mockData.goodForChildren,
+        goodForGroups: mockData.goodForGroups,
         allowsDogs: false,
-        restroom: true,
+        restroom: mockData.restroom,
+        acceptsCreditCards: mockData.paymentOptions.acceptsCreditCards,
+        acceptsDebitCards: mockData.paymentOptions.acceptsDebitCards,
+        acceptsCashOnly: mockData.paymentOptions.acceptsCashOnly,
         paymentOptions: {
-          acceptsCreditCards: true,
-          acceptsDebitCards: true,
-          acceptsCashOnly: false,
+          acceptsCreditCards: mockData.paymentOptions.acceptsCreditCards,
+          acceptsDebitCards: mockData.paymentOptions.acceptsDebitCards,
+          acceptsCashOnly: mockData.paymentOptions.acceptsCashOnly,
         },
-        generativeSummary: 'This is a generative summary of the restaurant',
+        generativeSummary: mockData.generativeSummary.overview.text,
         isFree: false,
         location: {
-          latitude: 37.7749,
-          longitude: -122.4194,
+          latitude: mockData.location.latitude,
+          longitude: mockData.location.longitude,
         },
-        formattedAddress: '123 Test St, San Francisco, CA 94105',
+        address: mockData.formattedAddress,
+        merchantId: null,
+        googleRating: mockData.rating,
+        latitude: mockData.location.latitude,
+        longitude: mockData.location.longitude,
       });
     });
 
     it('should handle a free place correctly', () => {
       // Arrange
       const mockData: ValidatedGoogleDetailsResponse = {
+        id: 'free-museum-123',
         name: 'Free Museum',
         priceLevel: 'PRICE_LEVEL_FREE',
         rating: 4.8,
@@ -134,6 +157,7 @@ describe('data-transformer', () => {
     it('should handle a place with unspecified price level', () => {
       // Arrange
       const mockData: ValidatedGoogleDetailsResponse = {
+        id: 'unknown-price-123',
         name: 'Unknown Price Place',
         priceLevel: 'PRICE_LEVEL_UNSPECIFIED',
         rating: 4.0,
@@ -157,6 +181,7 @@ describe('data-transformer', () => {
     it('should handle missing optional fields with default values', () => {
       // Arrange
       const mockData: ValidatedGoogleDetailsResponse = {
+        id: 'minimal-place-123',
         name: 'Minimal Place',
         rating: 3.5,
         userRatingCount: 10,
@@ -174,7 +199,8 @@ describe('data-transformer', () => {
 
       // Assert
       expect(result).toMatchObject({
-        name: 'Minimal Place',
+        id: 'minimal-place-123',
+        name: '',
         reviews: [],
         displayName: '',
         primaryTypeDisplayName: '',
@@ -202,13 +228,22 @@ describe('data-transformer', () => {
           latitude: 37.7749,
           longitude: -122.4194,
         },
-        formattedAddress: '123 Minimal St, San Francisco, CA 94105',
+        latitude: 37.7749,
+        longitude: -122.4194,
+        address: '123 Minimal St, San Francisco, CA 94105',
+        merchantId: null,
+        googleRating: 3.5,
+        rating: 3.5,
+        userRatingCount: 10,
+        openNow: null,
+        priceLevel: null,
       });
     });
 
     it('should handle missing nested fields correctly', () => {
       // Arrange
       const mockData: ValidatedGoogleDetailsResponse = {
+        id: 'partial-data-123',
         name: 'Partial Data Place',
         reviews: [],
         rating: 3.5,
@@ -251,6 +286,7 @@ describe('data-transformer', () => {
       priceLevels.forEach(({ input, expected, isFree }) => {
         // Arrange
         const mockData: ValidatedGoogleDetailsResponse = {
+          id: `${input.toLowerCase()}-place-123`,
           name: `${input} Place`,
           priceLevel: input,
           rating: 4.0,

--- a/src/services/places/details/data-transformer/data-transformer.ts
+++ b/src/services/places/details/data-transformer/data-transformer.ts
@@ -1,4 +1,9 @@
-import type { Detail } from '@/types/details';
+import { ReviewStatus } from '@prisma/client';
+import type {
+  PlaceWithReviews,
+  ReviewWithoutTimeStamps,
+} from '@/types/details';
+import { getReviewId } from '../get-review-id/get-review-id';
 import {
   mapPriceLevel,
   type ValidatedGoogleDetailsResponse,
@@ -6,45 +11,64 @@ import {
 
 export function transformDetailsData(
   data: ValidatedGoogleDetailsResponse
-): Detail {
-  // Map the price level to the Detail format
-  const mappedPriceLevel = mapPriceLevel(data.priceLevel);
-
-  // Check if the place is free
-  const isFree = data.priceLevel === 'PRICE_LEVEL_FREE';
+): PlaceWithReviews {
+  // Filter out reviews with empty text
+  const transformedReviews: ReviewWithoutTimeStamps[] = data.reviews
+    .map((review) => ({
+      placeId: data.id,
+      id: getReviewId(review.name),
+      status: ReviewStatus.DEFAULT,
+      rating: review.rating,
+      relativePublishTimeDescription: review.relativePublishTimeDescription,
+      text: review.text?.text ?? review.originalText?.text ?? '',
+    }))
+    .filter((review) => review.text !== '');
 
   // Transform to Detail type with default values for required fields
-  const normalizedData: Detail = {
-    name: data.name || '',
-    reviews: data.reviews,
-    rating: data.rating || 0,
-    priceLevel: mappedPriceLevel,
-    userRatingCount: data.userRatingCount || 0,
-    openNow: data.currentOpeningHours?.openNow || undefined,
-    displayName: data.displayName?.text || '',
-    primaryTypeDisplayName: data.primaryTypeDisplayName?.text || '',
-    takeout: data.takeout || false,
+  const normalizedData: PlaceWithReviews = {
+    id: data.id,
+    acceptsCashOnly: data.paymentOptions?.acceptsCashOnly || false,
+    acceptsCreditCards: data.paymentOptions?.acceptsCreditCards || false,
+    acceptsDebitCards: data.paymentOptions?.acceptsDebitCards || false,
+    address: data.formattedAddress || '',
+    allowsDogs: data.allowsDogs || false,
     delivery: data.delivery || false,
     dineIn: data.dineIn || false,
     editorialSummary: data.editorialSummary?.text || '',
-    outdoorSeating: data.outdoorSeating || false,
-    liveMusic: data.liveMusic || false,
-    menuForChildren: data.menuForChildren || false,
-    servesDessert: data.servesDessert || false,
-    servesCoffee: data.servesCoffee || false,
+    generativeSummary: data.generativeSummary?.overview?.text || '',
     goodForChildren: data.goodForChildren || false,
     goodForGroups: data.goodForGroups || false,
-    allowsDogs: data.allowsDogs || false,
+    isFree: data.priceLevel === 'PRICE_LEVEL_FREE',
+    latitude: data.location.latitude,
+    liveMusic: data.liveMusic || false,
+    longitude: data.location.longitude,
+    menuForChildren: data.menuForChildren || false,
+    merchantId: null,
+    name: data.displayName?.text || '',
+    openNow: data.currentOpeningHours?.openNow || null,
+    outdoorSeating: data.outdoorSeating || false,
+    priceLevel: mapPriceLevel(data.priceLevel),
+    primaryTypeDisplayName: data.primaryTypeDisplayName?.text || '',
+    googleRating: data.rating || 0,
     restroom: data.restroom || false,
-    paymentOptions: data.paymentOptions || {
-      acceptsCreditCards: false,
-      acceptsDebitCards: false,
-      acceptsCashOnly: false,
+    reviews: transformedReviews,
+    servesCoffee: data.servesCoffee || false,
+    servesDessert: data.servesDessert || false,
+    takeout: data.takeout || false,
+    userRatingCount: data.userRatingCount || 0,
+
+    // Following fields are for backwards compatibility with the old API
+    displayName: data.displayName?.text || '',
+    location: {
+      latitude: data.location.latitude,
+      longitude: data.location.longitude,
     },
-    generativeSummary: data.generativeSummary?.overview?.text || '',
-    isFree,
-    location: data.location,
-    formattedAddress: data.formattedAddress || '',
+    rating: data.rating || 0,
+    paymentOptions: {
+      acceptsCreditCards: data.paymentOptions?.acceptsCreditCards || false,
+      acceptsDebitCards: data.paymentOptions?.acceptsDebitCards || false,
+      acceptsCashOnly: data.paymentOptions?.acceptsCashOnly || false,
+    },
   };
 
   return normalizedData;

--- a/src/services/places/details/fetch-details/fetch-details.ts
+++ b/src/services/places/details/fetch-details/fetch-details.ts
@@ -22,6 +22,7 @@ export async function fetchDetails(id: string) {
     const baseUrl = env.GOOGLE_PLACES_URL;
 
     const fields = [
+      'id',
       'name',
       'rating',
       'reviews',

--- a/src/services/places/details/get-place-details-with-cache/get-place-details-with-cache.ts
+++ b/src/services/places/details/get-place-details-with-cache/get-place-details-with-cache.ts
@@ -1,16 +1,10 @@
 import { DETAILS_CONFIG } from '@/constants/details';
 import { redis } from '@/lib/redis';
-import type { DetailResponse, Detail } from '@/types/details';
+import type { DetailResponse, PlaceWithReviews } from '@/types/details';
 import { log } from '@/utils/log';
 import { fetchDetails } from '../fetch-details/fetch-details';
 import { generateCacheKey } from '../generate-cache-key/generate-cache-key';
-/**
- * Represents the options for fetching place details.
- *
- * @interface FetchPlaceDetailsOptions
- * @property {string} id - The ID of the place to fetch details for
- * @property {boolean} bypassCache - Whether to bypass the cache and fetch fresh data from the API
- */
+
 interface FetchPlaceDetailsOptions {
   id: string;
   bypassCache?: boolean;
@@ -31,7 +25,7 @@ export async function getPlaceDetailsWithCache({
 
   // Check cache if not bypassing
   if (!bypassCache && cacheKey) {
-    const cachedData = await redis.get<Detail>(cacheKey);
+    const cachedData = await redis.get<PlaceWithReviews>(cacheKey);
     if (cachedData) {
       log.success(`[DETAILS]Cache hit`);
 

--- a/src/services/places/details/get-review-id/get-review-id.test.ts
+++ b/src/services/places/details/get-review-id/get-review-id.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { getReviewId } from './get-review-id';
+
+describe('getReviewId', () => {
+  it('should return the review id', () => {
+    expect(
+      getReviewId(
+        'places/ChIJifIePKtZwokRVZ-UdRGkZzs/reviews/ChdDSUhNMG9nS0VJQ0FnTUR3eGREQzV3RRAB'
+      )
+    ).toBe('ChdDSUhNMG9nS0VJQ0FnTUR3eGREQzV3RRAB');
+  });
+
+  it('should handle invalid input', () => {
+    expect(getReviewId('')).toBe(undefined);
+    expect(getReviewId('places/ChIJifIePKtZwokRVZ-UdRGkZzs')).toBe(undefined);
+    expect(getReviewId('places/ChIJifIePKtZwokRVZ-UdRGkZzs/reviews')).toBe(
+      undefined
+    );
+  });
+});

--- a/src/services/places/details/get-review-id/get-review-id.ts
+++ b/src/services/places/details/get-review-id/get-review-id.ts
@@ -1,0 +1,8 @@
+// takes an id from a review that looks like this:
+// "places/ChIJifIePKtZwokRVZ-UdRGkZzs/reviews/ChdDSUhNMG9nS0VJQ0FnTUR3eGREQzV3RRAB"
+// and returns the id:
+// "ChdDSUhNMG9nS0VJQ0FnTUR3eGREQzV3RRAB"
+
+export function getReviewId(id: string) {
+  return id.split('/reviews/')[1];
+}

--- a/src/services/places/details/validator/details-validator.test.ts
+++ b/src/services/places/details/validator/details-validator.test.ts
@@ -47,6 +47,7 @@ describe('details-validator', () => {
   describe('googleDetailsResponseSchema', () => {
     it('should validate a valid response', () => {
       const validResponse = {
+        id: 'test_place_123',
         name: 'Test Place',
         priceLevel: 'PRICE_LEVEL_MODERATE',
         rating: 4.5,
@@ -57,6 +58,7 @@ describe('details-validator', () => {
       const result = googleDetailsResponseSchema.safeParse(validResponse);
       expect(result.success).toBe(true);
       if (result.success) {
+        expect(result.data.id).toBe('test_place_123');
         expect(result.data.name).toBe('Test Place');
         expect(result.data.priceLevel).toBe('PRICE_LEVEL_MODERATE');
         expect(result.data.rating).toBe(4.5);
@@ -70,6 +72,7 @@ describe('details-validator', () => {
 
     it('should apply default values for optional fields', () => {
       const minimalResponse = {
+        id: 'minimal_place_123',
         name: 'Test Place',
         rating: 4.0,
         userRatingCount: 50,
@@ -79,6 +82,7 @@ describe('details-validator', () => {
       const result = googleDetailsResponseSchema.safeParse(minimalResponse);
       expect(result.success).toBe(true);
       if (result.success) {
+        expect(result.data.id).toBe('minimal_place_123');
         expect(result.data.name).toBe('Test Place');
         expect(result.data.priceLevel).toBe('PRICE_LEVEL_UNSPECIFIED');
         expect(result.data.reviews).toEqual([]);
@@ -87,6 +91,7 @@ describe('details-validator', () => {
 
     it('should accept responses without a name', () => {
       const responseWithoutName = {
+        id: 'no_name_place_123',
         priceLevel: 'PRICE_LEVEL_MODERATE',
         rating: 4.5,
         userRatingCount: 100,
@@ -99,6 +104,7 @@ describe('details-validator', () => {
 
     it('should accept responses without a rating', () => {
       const responseWithoutRating = {
+        id: 'no_rating_place_123',
         name: 'Test Place',
         priceLevel: 'PRICE_LEVEL_MODERATE',
         userRatingCount: 100,
@@ -113,6 +119,7 @@ describe('details-validator', () => {
 
     it('should accept responses without a userRatingCount', () => {
       const responseWithoutUserRatingCount = {
+        id: 'no_rating_count_place_123',
         name: 'Test Place',
         priceLevel: 'PRICE_LEVEL_MODERATE',
         rating: 4.5,
@@ -127,6 +134,7 @@ describe('details-validator', () => {
 
     it('should validate a response with reviews', () => {
       const responseWithReviews = {
+        id: 'reviews_place_123',
         name: 'Test Place',
         rating: 4.5,
         userRatingCount: 100,
@@ -230,6 +238,7 @@ describe('details-validator', () => {
 
     it('should validate a response with payment options', () => {
       const responseWithPaymentOptions = {
+        id: 'payment_options_place_123',
         name: 'Test Place',
         rating: 4.5,
         userRatingCount: 100,
@@ -254,6 +263,7 @@ describe('details-validator', () => {
 
     it('should validate a response with PRICE_LEVEL_FREE', () => {
       const responseWithFreePrice = {
+        id: 'free_place_123',
         name: 'Free Museum',
         rating: 4.8,
         userRatingCount: 200,
@@ -272,6 +282,7 @@ describe('details-validator', () => {
 
     it('should reject invalid price level values', () => {
       const invalidPriceLevel = {
+        id: 'invalid_price_place_123',
         name: 'Test Place',
         rating: 4.5,
         userRatingCount: 100,
@@ -296,6 +307,7 @@ describe('details-validator', () => {
 
       priceLevels.forEach((priceLevel) => {
         const response = {
+          id: `price_level_${priceLevel}`,
           name: `${priceLevel} Place`,
           rating: 4.0,
           userRatingCount: 50,
@@ -313,6 +325,7 @@ describe('details-validator', () => {
 
     it('should filter out reviews without text.text or originalText.text', () => {
       const responseWithMixedReviews = {
+        id: 'mixed_reviews_place_123',
         name: 'Test Place',
         rating: 4.5,
         userRatingCount: 100,
@@ -419,6 +432,22 @@ describe('details-validator', () => {
         expect(result.data.reviews[0].name).toBe('Valid Review');
         expect(result.data.reviews[0].text?.text).toBe('Great place!');
         expect(result.data.reviews[0].originalText?.text).toBe('Great place!');
+      }
+    });
+
+    it('should reject responses without an id', () => {
+      const responseWithoutId = {
+        name: 'Test Place',
+        rating: 4.5,
+        userRatingCount: 100,
+        ...defaultLocation,
+      };
+
+      const result = googleDetailsResponseSchema.safeParse(responseWithoutId);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].path[0]).toBe('id');
+        expect(result.error.issues[0].message).toBe('Required');
       }
     });
   });

--- a/src/services/places/details/validator/details-validator.ts
+++ b/src/services/places/details/validator/details-validator.ts
@@ -34,6 +34,7 @@ const priceLevelEnum = z.enum([
 ]);
 
 export const googleDetailsResponseSchema = z.object({
+  id: z.string(),
   name: z.string().optional(),
   displayName: textObjectSchema.optional(),
   primaryTypeDisplayName: textObjectSchema.optional(),

--- a/src/types/admin-user-favorites.d.ts
+++ b/src/types/admin-user-favorites.d.ts
@@ -1,7 +1,7 @@
 import type { Favorite, Place } from '@prisma/client';
 
 export type FavoriteWithPlace = Favorite & {
-  place: Pick<Place, 'name' | 'description'>;
+  place: Pick<Place, 'name' | 'editorialSummary'>;
 };
 
 export type FavoriteResponse = {

--- a/src/types/admin-user-ratings.d.ts
+++ b/src/types/admin-user-ratings.d.ts
@@ -1,7 +1,7 @@
 import type { Place, Rating } from '@prisma/client';
 
 export type RatingWithPlace = Rating & {
-  place: Pick<Place, 'name' | 'description'>;
+  place: Pick<Place, 'name' | 'editorialSummary'>;
 };
 
 export type RatingResponse = {

--- a/src/types/details.d.ts
+++ b/src/types/details.d.ts
@@ -1,76 +1,27 @@
 import type { CachedResponse } from './generics';
-import type { GooglePlaceDetails, Review } from './google-places-details';
+import type { Place, Review } from '@prisma/client';
 
-export type Detail = {
-  name: GooglePlaceDetails['name'];
-  reviews: {
-    name: Review['name'];
-    relativePublishTimeDescription: Review['relativePublishTimeDescription'];
-    rating: Review['rating'];
-    text?: {
-      text?: Review['text']['text'];
-      languageCode?: Review['text']['languageCode'];
-    };
-    originalText?: {
-      text?: Review['originalText']['text'];
-      languageCode?: Review['originalText']['languageCode'];
-    };
-  }[];
-  rating: GooglePlaceDetails['rating'];
-  priceLevel: (1 | 2 | 3 | 4) | null;
-  userRatingCount: GooglePlaceDetails['userRatingCount'];
-  openNow?: GooglePlaceDetails['currentOpeningHours']['openNow'];
-  displayName: GooglePlaceDetails['displayName']['text'];
-  primaryTypeDisplayName: GooglePlaceDetails['primaryTypeDisplayName']['text'];
-  takeout: GooglePlaceDetails['takeout'];
-  delivery: GooglePlaceDetails['delivery'];
-  dineIn: GooglePlaceDetails['dineIn'];
-  editorialSummary: GooglePlaceDetails['editorialSummary']['text'];
-  outdoorSeating: GooglePlaceDetails['outdoorSeating'];
-  liveMusic: GooglePlaceDetails['liveMusic'];
-  menuForChildren: GooglePlaceDetails['menuForChildren'];
-  servesDessert: GooglePlaceDetails['servesDessert'];
-  servesCoffee: GooglePlaceDetails['servesCoffee'];
-  goodForChildren: GooglePlaceDetails['goodForChildren'];
-  goodForGroups: GooglePlaceDetails['goodForGroups'];
-  allowsDogs: GooglePlaceDetails['allowsDogs'];
-  restroom: GooglePlaceDetails['restroom'];
-  paymentOptions: GooglePlaceDetails['paymentOptions'];
-  generativeSummary: GooglePlaceDetails['generativeSummary']['overview']['text'];
-  isFree: boolean;
-  location: GooglePlaceDetails['location'];
-  formattedAddress: GooglePlaceDetails['formattedAddress'];
+export type ReviewWithoutTimeStamps = Omit<Review, 'createdAt' | 'updatedAt'>;
+
+export type PlaceWithoutTimeStamps = Omit<Place, 'createdAt' | 'updatedAt'> & {
+  displayName: string;
+  location: {
+    latitude: number;
+    longitude: number;
+  };
+  rating: number;
+  paymentOptions: {
+    acceptsCreditCards: boolean;
+    acceptsDebitCards: boolean;
+    acceptsCashOnly: boolean;
+  };
+};
+
+export type PlaceWithReviews = PlaceWithoutTimeStamps & {
+  reviews: ReviewWithoutTimeStamps[];
 };
 
 /**
  * Response type for the details API endpoint
  */
-export type DetailResponse = CachedResponse<Detail>;
-
-export type GoogleDetailsResponse = {
-  name: GooglePlaceDetails['name'];
-  reviews: GooglePlaceDetails['reviews'];
-  rating: GooglePlaceDetails['rating'];
-  priceLevel: GooglePlaceDetails['priceLevel'];
-  userRatingCount: GooglePlaceDetails['userRatingCount'];
-  currentOpeningHours: GooglePlaceDetails['currentOpeningHours'];
-  displayName: GooglePlaceDetails['displayName'];
-  primaryTypeDisplayName: GooglePlaceDetails['primaryTypeDisplayName'];
-  takeout: GooglePlaceDetails['takeout'];
-  delivery: GooglePlaceDetails['delivery'];
-  dineIn: GooglePlaceDetails['dineIn'];
-  editorialSummary: GooglePlaceDetails['editorialSummary'];
-  outdoorSeating: GooglePlaceDetails['outdoorSeating'];
-  liveMusic: GooglePlaceDetails['liveMusic'];
-  menuForChildren: GooglePlaceDetails['menuForChildren'];
-  servesDessert: GooglePlaceDetails['servesDessert'];
-  servesCoffee: GooglePlaceDetails['servesCoffee'];
-  goodForChildren: GooglePlaceDetails['goodForChildren'];
-  goodForGroups: GooglePlaceDetails['goodForGroups'];
-  allowsDogs: GooglePlaceDetails['allowsDogs'];
-  restroom: GooglePlaceDetails['restroom'];
-  paymentOptions: GooglePlaceDetails['paymentOptions'];
-  generativeSummary: GooglePlaceDetails['generativeSummary'];
-  location: GooglePlaceDetails['location'];
-  formattedAddress: GooglePlaceDetails['formattedAddress'];
-};
+export type DetailResponse = CachedResponse<PlaceWithReviews>;


### PR DESCRIPTION
#### Description:
- when we hit the `/api/places/details` endpoint, create a place in db with all fields from googles response
  - update endpoint response to now by prisma response type (with backwards compatibility)
- update `/api/places/favorite` endpoint to no longer return place
- update `/api/places/rating` endpoint to no longer return place
- add ability to rate / favorite a place from the admin console (`/admin/api-reference/places/details`)

#### Attachment(s):
https://github.com/user-attachments/assets/777f43c0-9a01-4f2d-8cf1-4a7ffbc5f572

#### Note(s):
- video is a bit out of date, made sure to invalidate the user favorites / ratings query after you favorite / rate something so when you go back to the user page, those are updated without having to refresh
